### PR TITLE
Add support for double dash command passing in cluster console

### DIFF
--- a/buildrpm/ocne.spec
+++ b/buildrpm/ocne.spec
@@ -6,7 +6,7 @@
 
 Name: ocne
 Version: 2.0.1
-Release: 2%{dist}
+Release: 3%{dist}
 Vendor: Oracle America
 Summary: Oracle Cloud Native Environment command line interface
 License: UPL 1.0
@@ -50,6 +50,10 @@ chmod 755 %{buildroot}%{_sysconfdir}/bash_completion.d/ocne
 %{_sysconfdir}/bash_completion.d/ocne
 
 %changelog
+
+* Fri Sep 13 2024 Daniel Krasinski <daniel.krasinski@oracle.com> - 2.0.1-3
+- Add support for double dash commands when using the cluster console
+
 * Thu Sep 12 2024 Daniel Krasinski <daniel.krasinski@oracle.com> - 2.0.1-2
 - Change the default ostree registry to include a transport
 - Tolerate less well specified ostree registry references

--- a/cmd/cluster/console/console.go
+++ b/cmd/cluster/console/console.go
@@ -43,7 +43,7 @@ func NewCmd() *cobra.Command {
 		Use:   CommandName,
 		Short: helpShort,
 		Long:  helpLong,
-		Args:  cobra.MatchAll(cobra.ExactArgs(0), cobra.OnlyValidArgs),
+		Args:  cobra.MatchAll(cobra.OnlyValidArgs),
 	}
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
@@ -63,6 +63,12 @@ func NewCmd() *cobra.Command {
 
 // RunCmd runs the "ocne cluster console" command
 func RunCmd(cmd *cobra.Command) error {
-	err := console.Console(kubeConfig, nodeName, toolbox, chroot)
+	// Get any command that was provided
+	cmds := []string{}
+	if cmd.ArgsLenAtDash() >= 0 {
+		cmds = cmd.Flags().Args()[cmd.ArgsLenAtDash():]
+	}
+
+	err := console.Console(kubeConfig, nodeName, toolbox, chroot, cmds)
 	return err
 }

--- a/test/bats/console/console.bats
+++ b/test/bats/console/console.bats
@@ -5,6 +5,10 @@
 #
 # bats file_tags=CONSOLE
 
+setup_file() {
+	export BATS_NO_PARALLELIZE_WITHIN_FILE=true
+}
+
 @test "Console can execute commands on a node" {
 	run kubectl get node -o=jsonpath='{.items[0].metadata.name}'
 	[ "$status" -eq 0 ]
@@ -15,4 +19,48 @@
 
 	run bash -c "echo false | timeout 1m ocne cluster console --node $NODE"
 	[ "$status" -ne 0 ]
+
+	run timeout 1m ocne cluster console --node $NODE -- true
+	[ "$status" -eq 0 ]
+
+	run timeout 1m ocne cluster console --node $NODE -- false
+	[ "$status" -ne 0 ]
+}
+
+@test "Console can execute commands on a node using --direct" {
+	run kubectl get node -o=jsonpath='{.items[0].metadata.name}'
+	[ "$status" -eq 0 ]
+	NODE="$output"
+
+	run bash -c "echo true | timeout 1m ocne cluster console --node $NODE --direct"
+	[ "$status" -eq 0 ]
+
+	run bash -c "echo false | timeout 1m ocne cluster console --node $NODE --direct"
+	[ "$status" -ne 0 ]
+
+	run timeout 1m ocne cluster console --node $NODE --direct -- true
+	[ "$status" -eq 0 ]
+
+	run timeout 1m ocne cluster console --node $NODE --direct -- false
+	[ "$status" -ne 0 ]
+}
+
+@test "Console without --direct runs in the container" {
+	run kubectl get node -o=jsonpath='{.items[0].metadata.name}'
+	[ "$status" -eq 0 ]
+	NODE="$output"
+
+	run timeout 1m ocne cluster console --node $NODE --direct -- ls /
+	[ "$status" -eq 0 ]
+	echo "$output" | grep -qv ostree
+}
+
+@test "Console with --direct runs in the host" {
+	run kubectl get node -o=jsonpath='{.items[0].metadata.name}'
+	[ "$status" -eq 0 ]
+	NODE="$output"
+
+	run timeout 1m ocne cluster console --node $NODE --direct -- ls /
+	[ "$status" -eq 0 ]
+	echo "$output" | grep -q ostree
 }


### PR DESCRIPTION
Adds the ability to specify commands to run in the cluster console using "--", as with kubectl and other CLIs.

```
1..4
ok 1 Console can execute commands on a node
ok 2 Console can execute commands on a node using --direct
ok 3 Console without --direct runs in the container
ok 4 Console with --direct runs in the host
```