### PR TITLE
Change CLI to override clusterConfig with command line arguments

### DIFF
--- a/pkg/cmdutil/config.go
+++ b/pkg/cmdutil/config.go
@@ -20,7 +20,7 @@ func GetFullConfig(defaultConfig *types.Config, clusterConfig *types.ClusterConf
 			return nil, nil, err
 		}
 
-		mcc := types.MergeClusterConfig(clusterConfig, ncc)
+		mcc := types.MergeClusterConfig(ncc, clusterConfig)
 		clusterConfig = &mcc
 	}
 	df, err := config.GetDefaultConfig()


### PR DESCRIPTION
In this PR, I changed the CLI to override the clusterConfig provided by the user with the relevant command line arguments, if they are given. I tested this by running the following command below that started up a cluster with the correct name, where ~/testnamebug.yaml contained `name: doNotUse`. 
```./ocne cluster start -C nametoUse -c ~/testnamebug.yaml
INFO[2024-09-18T10:45:39-04:00] Creating new Kubernetes cluster with version 1.29 named nametoUse 
INFO[2024-09-18T10:46:03-04:00] Waiting for the Kubernetes cluster to be ready: ok 
INFO[2024-09-18T10:46:13-04:00] Installing flannel into kube-flannel: ok 
INFO[2024-09-18T10:46:15-04:00] Installing ui into ocne-system: ok 
INFO[2024-09-18T10:46:16-04:00] Installing ocne-catalog into ocne-system: ok 
INFO[2024-09-18T10:46:16-04:00] Kubernetes cluster was created successfully  
INFO[2024-09-18T10:47:06-04:00] Waiting for the UI to be ready: ok 
```