### PR TITLE
Add catalog option to ocne application update (2)

### DIFF
--- a/cmd/application/update/update.go
+++ b/cmd/application/update/update.go
@@ -5,13 +5,14 @@ package update
 
 import (
 	"fmt"
-	log "github.com/sirupsen/logrus"
-	"github.com/spf13/cobra"
+
 	"github.com/oracle-cne/ocne/cmd/constants"
 	"github.com/oracle-cne/ocne/pkg/cmdutil"
 	"github.com/oracle-cne/ocne/pkg/commands/application"
 	"github.com/oracle-cne/ocne/pkg/commands/application/update"
 	pkgconst "github.com/oracle-cne/ocne/pkg/constants"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
 )
 
 const (
@@ -35,6 +36,7 @@ var values string
 var version string
 var namespace string
 var builtin bool
+var catalogName string
 
 const (
 	flagRelease      = "release"
@@ -56,6 +58,10 @@ const (
 	flagBuiltIn      = "built-in-catalog"
 	flagBuiltInShort = "b"
 	flagBuiltInHelp  = "Update the built-in catalog in the ocne-system namespace."
+
+	flagCatalogName      = "catalog"
+	flagCatalogNameShort = "c"
+	flagCatalogNameHelp  = "The name of the catalog that contains the application."
 )
 
 func NewCmd() *cobra.Command {
@@ -78,10 +84,12 @@ func NewCmd() *cobra.Command {
 	cmd.Flags().StringVarP(&namespace, flagNamespace, flagNamespaceShort, "", flagNamespaceHelp)
 	cmd.Flags().StringVarP(&release, flagRelease, flagReleaseShort, "", flagReleaseHelp)
 	cmd.Flags().StringVarP(&version, flagVersion, flagVersionShort, "", flagVersionHelp)
+	cmd.Flags().StringVarP(&catalogName, flagCatalogName, flagCatalogNameShort, pkgconst.DefaultCatalogName, flagCatalogNameHelp)
 
 	cmd.MarkFlagsMutuallyExclusive(flagBuiltIn, flagRelease)
 	cmd.MarkFlagsMutuallyExclusive(flagBuiltIn, flagVersion)
 	cmd.MarkFlagsMutuallyExclusive(flagBuiltIn, flagNamespace)
+	cmd.MarkFlagsMutuallyExclusive(flagBuiltIn, flagCatalogName)
 
 	return cmd
 }
@@ -99,6 +107,7 @@ func RunCmd(cmd *cobra.Command) error {
 	err := update.Update(application.UpdateOptions{
 		Namespace:      namespace,
 		KubeConfigPath: kubeConfig,
+		CatalogName:    catalogName,
 		Version:        version,
 		ReleaseName:    release,
 		Values:         values,

--- a/doc/manpages/ocne-application.md
+++ b/doc/manpages/ocne-application.md
@@ -47,7 +47,7 @@ SUBCOMMANDS
     The name of the catalog that contains the application.
 
 `-b`, `--built-in-catalog` *built-in-catalog*
-    Install the built-in catalog into the ocne-system namespace.  The cluster container runtime must be configured with the image registry name..
+    Install the built-in catalog into the ocne-system namespace.  The cluster container runtime must be configured with the image registry name.
 
 `-N`, `--name` *application-name*
     The name of the application to install.
@@ -95,6 +95,9 @@ SUBCOMMANDS
 
 `-b`, `--built-in-catalog` *built-in-catalog*
     Update the built-in catalog in the ocne-system namespace.
+
+`-c`, `--catalog` *catalog*
+The name of the catalog that contains the application.
 
 `-r`, `--release` *release-name*
     The name of the release of the application.

--- a/pkg/commands/application/types.go
+++ b/pkg/commands/application/types.go
@@ -54,7 +54,7 @@ type ShowOptions struct {
 // InstallOptions are the options for the application install command
 type InstallOptions struct {
 
-	// Catalog is the catalog object that is used to gather information about the app-catalog
+	// Catalog is the catalog object used to gather information about the app-catalog
 	Catalog *catalog.Catalog
 
 	// KubeConfigPath is the path of the kubeconfig file
@@ -80,6 +80,9 @@ type InstallOptions struct {
 	Overrides []helm.HelmOverrides
 }
 type UpdateOptions struct {
+
+	// Catalog is the name of the catalog used to gather information about the app-catalog
+	CatalogName string
 
 	// ReleaseName is the release name of the instance of the application
 	ReleaseName string

--- a/pkg/commands/application/update/update.go
+++ b/pkg/commands/application/update/update.go
@@ -6,7 +6,6 @@ package update
 import (
 	"fmt"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/oracle-cne/ocne/pkg/catalog"
 	"github.com/oracle-cne/ocne/pkg/commands/application"
 	"github.com/oracle-cne/ocne/pkg/commands/application/install"
@@ -16,6 +15,7 @@ import (
 	"github.com/oracle-cne/ocne/pkg/helm"
 	"github.com/oracle-cne/ocne/pkg/k8s/client"
 	"github.com/oracle-cne/ocne/pkg/util/logutils"
+	log "github.com/sirupsen/logrus"
 )
 
 // Update takes in a set of update options and returns an error that indicates whether the update was successful
@@ -49,7 +49,7 @@ func Update(opt application.UpdateOptions) error {
 	// Get the catalog information along with setting the port-forward
 	cat, err := search.Search(catalog.SearchOptions{
 		KubeConfigPath: opt.KubeConfigPath,
-		CatalogName:    constants.DefaultCatalogName,
+		CatalogName:    opt.CatalogName,
 		Pattern:        appName,
 	})
 	if err != nil {


### PR DESCRIPTION
Added option to ```ocne application update``` to specify which catalog to use.

Test case to verify change worked:
```
ocne cluster start -u false
ocne catalog add --uri https://oracle.github.io/weblogic-kubernetes-operator --name "WebLogic Kubernetes Operator"
ocne application install -c "WebLogic Kubernetes Operator" --release weblogic-operator --namespace weblogic-operator --name weblogic-operator --version 4.2.3
ocne application update --release weblogic-operator --namespace weblogic-operator --version 4.2.7 --catalog "WebLogic Kubernetes Operator"
```

I also verified the application tests passed:
```
make integration-test TEST_PATTERN=default TEST_FILTERS="--filter-tags APPLICATION"
```