### PR TITLE
Add Make Target For Release Tests, so that all tests are run 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,6 +120,13 @@ capi-test: $(GOCOVERDIR) $(MERGED_COVER_DIR) $(BATS_RESULT_DIR) build-cli-instru
 	$(GO) tool covdata textfmt -i=$(MERGED_COVER_DIR) -o=$(CODE_COVERAGE)
 	echo To view coverage data, execute \"go tool cover -html=$(CODE_COVERAGE)\"
 
+.PHONY: release-test
+release-test: $(GOCOVERDIR) $(MERGED_COVER_DIR) $(BATS_RESULT_DIR) build-cli-instrumented
+	cd test && PATH="$(MAKEFILE_DIR)/$(OUT_DIR)/$(shell go env GOOS)_$(shell go env GOARCH)_instrumented:$$PATH" ./run-tests.sh '$(TEST_PATTERN)' 1 1
+	$(GO) tool covdata merge -i=$(GOCOVERDIR) -o=$(MERGED_COVER_DIR)
+	$(GO) tool covdata textfmt -i=$(MERGED_COVER_DIR) -o=$(CODE_COVERAGE)
+	echo To view coverage data, execute \"go tool cover -html=$(CODE_COVERAGE)\"
+
 clean-charts:
 	rm -rf $(CHART_EMBED)
 	rm -rf $(CHART_GIT_DIR)

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -7,7 +7,10 @@ PATTERN=${1:-'.*'}
 SUITE_JOBS=${SUITE_JOBS:-2}
 TEST_JOBS=${TEST_JOBS:-2}
 INCLUDE_CAPI=${2:-0}
-TEST_FILTERS=${TEST_FILTERS:-'--filter-tags !CAPI,!CLUSTER_UPGRADE'}
+RELEASE_TEST=${3:-0}
+if [[ $RELEASE_TEST -eq 0 ]]; then
+	TEST_FILTERS=${TEST_FILTERS:-'--filter-tags !CAPI,!CLUSTER_UPGRADE'}
+fi
 TEST_K8S_VERSION=${TEST_K8S_VERSION:=""}
 
 # Default to the latest k8s version

--- a/test/setups/multi-node/setup
+++ b/test/setups/multi-node/setup
@@ -14,7 +14,7 @@ setup_suite() {
 		ocne cluster start --auto-start-ui false --session "$OCNE_LIBVIRT_URI" --cluster-name remoteworkers --control-plane-nodes 2 --worker-nodes 2 $(echo $K8S_VERSION_FLAG)
 	fi
 	export KUBECONFIG=~/.kube/kubeconfig.$CLUSTER_NAME.local
-	export CAPI_NAME=capi-named
+	export CAPI_NAME=capi-multi-node
 
 	# wait for cluster to come up
 	kubectl rollout status deployment -n kube-system coredns


### PR DESCRIPTION
In this PR, I add a target for the make release tests, so that all of the release tests are run. I tested this on an Oracle Linux 8 machine, where it was configured to run all of the release tests when this make target was ran.