### PR TITLE
Add option to "ocne app update" to reset the overrides to the ones built into the chart

### DIFF
--- a/cmd/application/update/update.go
+++ b/cmd/application/update/update.go
@@ -37,6 +37,7 @@ var version string
 var namespace string
 var builtin bool
 var catalogName string
+var resetValues bool
 
 const (
 	flagRelease      = "release"
@@ -62,6 +63,9 @@ const (
 	flagCatalogName      = "catalog"
 	flagCatalogNameShort = "c"
 	flagCatalogNameHelp  = "The name of the catalog that contains the application."
+
+	flagResetValues     = "reset-values"
+	flagResetValuesHelp = "Reset the values to the ones built into the chart. If --values is also provided, it will be treated as a new set of overrides."
 )
 
 func NewCmd() *cobra.Command {
@@ -85,6 +89,7 @@ func NewCmd() *cobra.Command {
 	cmd.Flags().StringVarP(&release, flagRelease, flagReleaseShort, "", flagReleaseHelp)
 	cmd.Flags().StringVarP(&version, flagVersion, flagVersionShort, "", flagVersionHelp)
 	cmd.Flags().StringVarP(&catalogName, flagCatalogName, flagCatalogNameShort, pkgconst.DefaultCatalogName, flagCatalogNameHelp)
+	cmd.Flags().BoolVarP(&resetValues, flagResetValues, "", false, flagResetValuesHelp)
 
 	cmd.MarkFlagsMutuallyExclusive(flagBuiltIn, flagRelease)
 	cmd.MarkFlagsMutuallyExclusive(flagBuiltIn, flagVersion)
@@ -111,6 +116,7 @@ func RunCmd(cmd *cobra.Command) error {
 		Version:        version,
 		ReleaseName:    release,
 		Values:         values,
+		ResetValues:    resetValues,
 	})
 	if err != nil {
 		return err

--- a/doc/manpages/ocne-application.md
+++ b/doc/manpages/ocne-application.md
@@ -107,6 +107,10 @@ The name of the catalog that contains the application.
     value is not provided, the namespace from the current context of the
     kubeconfig is used.
 
+`--reset-values`
+    Reset the values to the ones built into the chart. If `--values` is also
+    provided, it will be treated as a new set of overrides.
+
 `-v`, `--version` *version*
     The version of the application to update to.  By default, the version
     is the latest stable version of the application.

--- a/pkg/commands/application/install/install.go
+++ b/pkg/commands/application/install/install.go
@@ -8,16 +8,14 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/oracle-cne/ocne/pkg/catalog"
 	"github.com/oracle-cne/ocne/pkg/commands/application"
 	"github.com/oracle-cne/ocne/pkg/commands/application/ls"
 	"github.com/oracle-cne/ocne/pkg/constants"
+	"github.com/oracle-cne/ocne/pkg/helm"
 	"github.com/oracle-cne/ocne/pkg/k8s/client"
 	"github.com/oracle-cne/ocne/pkg/util/logutils"
-
 	log "github.com/sirupsen/logrus"
-
-	"github.com/oracle-cne/ocne/pkg/catalog"
-	"github.com/oracle-cne/ocne/pkg/helm"
 )
 
 // Install parses a catalog for an entry with a given application name and version
@@ -58,8 +56,8 @@ func Install(opt application.InstallOptions) error {
 			FileOverride: opt.Values,
 		})
 	}
-	// Upload the helm chart that is stored at the temporary directory
-	_, err = helm.UpgradeChartFromArchive(kubeInfo, opt.ReleaseName, opt.Namespace, true, chartReader, false, false, overrides)
+	// Upload the helm chart stored at the temporary directory
+	_, err = helm.UpgradeChartFromArchive(kubeInfo, opt.ReleaseName, opt.Namespace, true, chartReader, false, false, overrides, opt.ResetValues)
 	return err
 }
 
@@ -111,7 +109,7 @@ func InstallInternalCatalog(kubeConfigPath string, namespace string) error {
 	}
 
 	// install the OCNE catalog application
-	apps := []ApplicationDescription{}
+	var apps []ApplicationDescription
 	apps = append(apps, NewInternalCatalogApplication(namespace))
 	if err := InstallApplications(apps, kubeConfigPath, false); err != nil {
 		return err

--- a/pkg/commands/application/types.go
+++ b/pkg/commands/application/types.go
@@ -78,6 +78,9 @@ type InstallOptions struct {
 	// Overrides is a list of overrides that get munged together.
 	// Later values take precedence over earlier ones.
 	Overrides []helm.HelmOverrides
+
+	// ResetValues is used to reset the values to the ones built into the chart.
+	ResetValues bool
 }
 type UpdateOptions struct {
 
@@ -98,6 +101,9 @@ type UpdateOptions struct {
 
 	// Values is the path to a file containing helm values that will be used for overrides
 	Values string
+
+	// ResetValues is used to reset the values to the ones built into the chart.
+	ResetValues bool
 }
 
 // TemplateOptions are the options for the application template command

--- a/pkg/commands/application/update/update.go
+++ b/pkg/commands/application/update/update.go
@@ -65,6 +65,7 @@ func Update(opt application.UpdateOptions) error {
 		Version:        opt.Version,
 		ReleaseName:    opt.ReleaseName,
 		Values:         opt.Values,
+		ResetValues:    opt.ResetValues,
 	})
 	return err
 }

--- a/pkg/helm/helmcli.go
+++ b/pkg/helm/helmcli.go
@@ -213,6 +213,7 @@ func UpgradeChart(kubeInfo *client.KubeInfo, releaseName string, namespace strin
 		client.Namespace = namespace
 		client.DryRun = dryRun
 		client.Wait = wait
+		client.ResetValues = resetValues
 
 		// Reuse the original set of input values as the base set of helm overrides
 		helmValues := map[string]interface{}{}

--- a/test/bats/application/update.bats
+++ b/test/bats/application/update.bats
@@ -1,0 +1,19 @@
+#! /usr/bin/env bats
+#
+# Copyright (c) 2024, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+#
+# bats file_tags=APPLICATION
+
+@test "Install and update the WebLogic Kubernetes Operator" {
+    ocne catalog add --uri https://oracle.github.io/weblogic-kubernetes-operator --name "WebLogic Kubernetes Operator"
+
+    # Override the image used to later verify that --reset-values works
+    ocne application install --release weblogic-operator --namespace weblogic-operator --name weblogic-operator --version 4.2.7 --catalog "WebLogic Kubernetes Operator" --values - <<EOF
+image: ghcr.io/oracle/weblogic-kubernetes-operator:4.1.2
+EOF
+    kubectl rollout status deployment -n weblogic-operator weblogic-operator -w
+    run kubectl get pods -n weblogic-operator -o yaml | grep image:
+    [ $status -ne 0 ]
+    [[ "$output" =~ 1.4.2 ]]
+}

--- a/test/bats/application/update.bats
+++ b/test/bats/application/update.bats
@@ -14,6 +14,27 @@ image: ghcr.io/oracle/weblogic-kubernetes-operator:4.1.2
 EOF
     kubectl rollout status deployment -n weblogic-operator weblogic-operator -w
     run kubectl get pods -n weblogic-operator -o yaml | grep image:
-    [ $status -ne 0 ]
-    [[ "$output" =~ 1.4.2 ]]
+    [ $status -eq 0 ]
+    [[ "$output" =~ 4.1.2 ]]
+
+    # Update to version 4.1.3 but use previous set of overrides.  The image tag should remain 1.4.2.
+    ocne application update --release weblogic-operator --namespace weblogic-operator --version 4.1.3 --catalog "WebLogic Kubernetes Operator"
+    kubectl rollout status deployment -n weblogic-operator weblogic-operator -w
+    run kubectl get pods -n weblogic-operator -o yaml | grep image:
+    [ $status -eq 0 ]
+    [[ "$output" =~ 4.1.2 ]]
+
+    # Update to version 4.1.4 and reset previous override values.
+    ocne application update --release weblogic-operator --namespace weblogic-operator --version 4.1.4 --catalog "WebLogic Kubernetes Operator"
+    kubectl rollout status deployment -n weblogic-operator weblogic-operator -w
+    run kubectl get pods -n weblogic-operator -o yaml | grep image:
+    [ $status -eq 0 ]
+    [[ "$output" =~ 4.1.4 ]]
+
+    # Update to version 4.2.7 and use previous override values (of which there should be none)
+    ocne application update --release weblogic-operator --namespace weblogic-operator --version 4.2.7 --catalog "WebLogic Kubernetes Operator"
+    kubectl rollout status deployment -n weblogic-operator weblogic-operator -w
+    run kubectl get pods -n weblogic-operator -o yaml | grep image:
+    [ $status -eq 0 ]
+    [[ "$output" =~ 4.2.7 ]]
 }

--- a/test/bats/application/update.bats
+++ b/test/bats/application/update.bats
@@ -13,28 +13,20 @@
 image: ghcr.io/oracle/weblogic-kubernetes-operator:4.1.2
 EOF
     kubectl rollout status deployment -n weblogic-operator weblogic-operator -w
-    run kubectl get pods -n weblogic-operator -o yaml | grep "image:"
-    [ $status -eq 0 ]
-    [[ "$output" =~ 4.1.2 ]]
+    kubectl get pods -n weblogic-operator -o yaml | grep "image:" | grep "4.1.2"
 
     # Update to version 4.1.3 but use previous set of overrides.  The image tag should remain 1.4.2.
     ocne application update --release weblogic-operator --namespace weblogic-operator --version 4.1.3 --catalog "WebLogic Kubernetes Operator"
     kubectl rollout status deployment -n weblogic-operator weblogic-operator -w
-    run kubectl get pods -n weblogic-operator -o yaml | grep "image:"
-    [ $status -eq 0 ]
-    [[ "$output" =~ 4.1.2 ]]
+    kubectl get pods -n weblogic-operator -o yaml | grep "image:" | grep "4.1.2"
 
     # Update to version 4.1.4 and reset previous override values.
     ocne application update --release weblogic-operator --namespace weblogic-operator --version 4.1.4 --catalog "WebLogic Kubernetes Operator"
     kubectl rollout status deployment -n weblogic-operator weblogic-operator -w
-    run kubectl get pods -n weblogic-operator -o yaml | grep "image:"
-    [ $status -eq 0 ]
-    [[ "$output" =~ 4.1.4 ]]
+    kubectl get pods -n weblogic-operator -o yaml | grep "image:" | grep "4.1.4"
 
     # Update to version 4.2.7 and use previous override values (of which there should be none)
     ocne application update --release weblogic-operator --namespace weblogic-operator --version 4.2.7 --catalog "WebLogic Kubernetes Operator"
     kubectl rollout status deployment -n weblogic-operator weblogic-operator -w
-    run kubectl get pods -n weblogic-operator -o yaml | grep "image:"
-    [ $status -eq 0 ]
-    [[ "$output" =~ 4.2.7 ]]
+    kubectl get pods -n weblogic-operator -o yaml | grep "image:" | grep "4.2.7"
 }

--- a/test/bats/application/update.bats
+++ b/test/bats/application/update.bats
@@ -9,7 +9,7 @@
     ocne catalog add --uri https://oracle.github.io/weblogic-kubernetes-operator --name "WebLogic Kubernetes Operator"
 
     # Override the image used to later verify that --reset-values works
-    ocne application install --release weblogic-operator --namespace weblogic-operator --name weblogic-operator --version 4.2.7 --catalog "WebLogic Kubernetes Operator" --values - <<EOF
+    ocne application install --release weblogic-operator --namespace weblogic-operator --name weblogic-operator --version 4.1.2 --catalog "WebLogic Kubernetes Operator" --values - <<EOF
 image: ghcr.io/oracle/weblogic-kubernetes-operator:4.1.2
 EOF
     kubectl rollout status deployment -n weblogic-operator weblogic-operator -w

--- a/test/bats/application/update.bats
+++ b/test/bats/application/update.bats
@@ -21,7 +21,7 @@ EOF
     kubectl get pods -n weblogic-operator -o yaml | grep "image:" | grep "4.1.2"
 
     # Update to version 4.1.4 and reset previous override values.
-    ocne application update --release weblogic-operator --namespace weblogic-operator --version 4.1.4 --catalog "WebLogic Kubernetes Operator"
+    ocne application update --release weblogic-operator --namespace weblogic-operator --version 4.1.4 --catalog "WebLogic Kubernetes Operator" --reset-values
     kubectl rollout status deployment -n weblogic-operator weblogic-operator -w
     kubectl get pods -n weblogic-operator -o yaml | grep "image:" | grep "4.1.4"
 

--- a/test/bats/application/update.bats
+++ b/test/bats/application/update.bats
@@ -13,28 +13,28 @@
 image: ghcr.io/oracle/weblogic-kubernetes-operator:4.1.2
 EOF
     kubectl rollout status deployment -n weblogic-operator weblogic-operator -w
-    run kubectl get pods -n weblogic-operator -o yaml | grep image:
+    run kubectl get pods -n weblogic-operator -o yaml | grep "image:"
     [ $status -eq 0 ]
     [[ "$output" =~ 4.1.2 ]]
 
     # Update to version 4.1.3 but use previous set of overrides.  The image tag should remain 1.4.2.
     ocne application update --release weblogic-operator --namespace weblogic-operator --version 4.1.3 --catalog "WebLogic Kubernetes Operator"
     kubectl rollout status deployment -n weblogic-operator weblogic-operator -w
-    run kubectl get pods -n weblogic-operator -o yaml | grep image:
+    run kubectl get pods -n weblogic-operator -o yaml | grep "image:"
     [ $status -eq 0 ]
     [[ "$output" =~ 4.1.2 ]]
 
     # Update to version 4.1.4 and reset previous override values.
     ocne application update --release weblogic-operator --namespace weblogic-operator --version 4.1.4 --catalog "WebLogic Kubernetes Operator"
     kubectl rollout status deployment -n weblogic-operator weblogic-operator -w
-    run kubectl get pods -n weblogic-operator -o yaml | grep image:
+    run kubectl get pods -n weblogic-operator -o yaml | grep "image:"
     [ $status -eq 0 ]
     [[ "$output" =~ 4.1.4 ]]
 
     # Update to version 4.2.7 and use previous override values (of which there should be none)
     ocne application update --release weblogic-operator --namespace weblogic-operator --version 4.2.7 --catalog "WebLogic Kubernetes Operator"
     kubectl rollout status deployment -n weblogic-operator weblogic-operator -w
-    run kubectl get pods -n weblogic-operator -o yaml | grep image:
+    run kubectl get pods -n weblogic-operator -o yaml | grep "image:"
     [ $status -eq 0 ]
     [[ "$output" =~ 4.2.7 ]]
 }


### PR DESCRIPTION
Added a ```--reset-values``` option to ```ocne application update``` as per the description in the linked task.  This new option is analogous to the underlying helm option with the same name.

Added a new bats test to verify this change.