### PR TITLE
Allow custom ostree transports for update configuration

### DIFF
--- a/cmd/image/create/create.go
+++ b/cmd/image/create/create.go
@@ -5,7 +5,6 @@ package create
 
 import (
 	"github.com/containers/image/v5/transports/alltransports"
-	"fmt"
 	"strings"
 
 	log "github.com/sirupsen/logrus"
@@ -15,7 +14,6 @@ import (
 	"github.com/oracle-cne/ocne/pkg/cmdutil"
 	"github.com/oracle-cne/ocne/pkg/commands/image/create"
 	"github.com/oracle-cne/ocne/pkg/config/types"
-	"github.com/oracle-cne/ocne/pkg/image"
 	pkgconst "github.com/oracle-cne/ocne/pkg/constants"
 )
 
@@ -78,13 +76,6 @@ func RunCmd(cmd *cobra.Command) error {
 	if imageTransport == nil {
 		// No transport protocol detected. Adding docker transport protocol as default.
 		cc.BootVolumeContainerImage = "docker://" + cc.BootVolumeContainerImage
-	}
-
-	// Try to be polite by accepting "regular" container registry formats.
-	// Not everyone is familiar with the requirements for ostree.
-	_, _, _, err = image.ParseOstreeReference(cc.OsRegistry)
-	if err != nil {
-		cc.OsRegistry = fmt.Sprintf("ostree-unverified-registry:%s", cc.OsRegistry)
 	}
 
 	// Make sure we create the new image using the base image that goes with the requested version of k8s.

--- a/cmd/image/create/create.go
+++ b/cmd/image/create/create.go
@@ -82,7 +82,7 @@ func RunCmd(cmd *cobra.Command) error {
 
 	// Try to be polite by accepting "regular" container registry formats.
 	// Not everyone is familiar with the requirements for ostree.
-	_, _, err = image.ParseOstreeReference(cc.OsRegistry)
+	_, _, _, err = image.ParseOstreeReference(cc.OsRegistry)
 	if err != nil {
 		cc.OsRegistry = fmt.Sprintf("ostree-unverified-registry:%s", cc.OsRegistry)
 	}

--- a/pkg/cmdutil/config.go
+++ b/pkg/cmdutil/config.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/oracle-cne/ocne/pkg/config"
 	"github.com/oracle-cne/ocne/pkg/config/types"
+	"github.com/oracle-cne/ocne/pkg/image"
 )
 
 func GetFullConfig(defaultConfig *types.Config, clusterConfig *types.ClusterConfig, clusterConfigPath string) (*types.Config, *types.ClusterConfig, error) {
@@ -29,6 +30,13 @@ func GetFullConfig(defaultConfig *types.Config, clusterConfig *types.ClusterConf
 
 	ndf := types.MergeConfig(df, defaultConfig)
 	cc := types.OverlayConfig(clusterConfig, &ndf)
+
+	// Be as friendly as can be
+	img, err := image.MakeOstreeReference(cc.OsRegistry)
+	if err != nil {
+		return nil, nil, err
+	}
+	cc.OsRegistry = img
 
 	return &ndf, &cc, nil
 }

--- a/pkg/commands/image/create/ostree.go
+++ b/pkg/commands/image/create/ostree.go
@@ -45,7 +45,7 @@ func createOstreeImage(cc *copyConfig) error {
 	containerImage := fmt.Sprintf("%s:%s", ostreeTransport, registry)
 	podmanImage := fmt.Sprintf("%s:%s", registry, tag)
 
-	log.Debugf("The podman image is %s", registry)
+	log.Debugf("The podman image is %s", podmanImage)
 	script := fmt.Sprintf(ostreeScript, cc.httpsProxy, cc.httpProxy, cc.noProxy, containerImage, podmanImage, cc.imageArchitecture)
 
 	waitors := []*logutils.Waiter{

--- a/pkg/commands/image/create/ostree.go
+++ b/pkg/commands/image/create/ostree.go
@@ -35,11 +35,17 @@ func createOstreeImage(cc *copyConfig) error {
 	// Convert the given container image to something that can be used
 	// by the script.  Notable, it hacks the tag off the ostree image
 	// and hacks the transport off to generate the podman image.
-	containerImage, podmanImage, err := image.ParseOstreeReference(cc.ostreeContainerImage)
+	ostreeTransport, registry, tag, err := image.ParseOstreeReference(cc.ostreeContainerImage)
 	if err != nil {
 		return err
 	}
-	log.Debugf("The podman image is %s", podmanImage)
+	if tag == "" {
+		return fmt.Errorf("ostree image %s requires a tag", cc.ostreeContainerImage)
+	}
+	containerImage := fmt.Sprintf("%s:%s", ostreeTransport, registry)
+	podmanImage := fmt.Sprintf("%s:%s", registry, tag)
+
+	log.Debugf("The podman image is %s", registry)
 	script := fmt.Sprintf(ostreeScript, cc.httpsProxy, cc.httpProxy, cc.noProxy, containerImage, podmanImage, cc.imageArchitecture)
 
 	waitors := []*logutils.Waiter{

--- a/pkg/image/registry.go
+++ b/pkg/image/registry.go
@@ -48,7 +48,7 @@ func AddDefaultRegistry(imageToChange string, registry string) (string, error) {
 // "ostree-unverified-image:container-registry.oracle.com/olcne/ock-ostree:1.30"
 // returns "ostree-unverified-image", "container-registry.oracle.com/olcne/ock-ostree"
 // and "1.30".  It is not necessary that a tag is present, but all the rest of the
-// fields are reuired.
+// fields are required.
 func ParseOstreeReference(img string) (string, string, string, error) {
 	// Important stuff is colon delimited.
 	fields := strings.Split(img, ":")

--- a/pkg/image/registry.go
+++ b/pkg/image/registry.go
@@ -127,3 +127,18 @@ func ParseOstreeReference(img string) (string, string, string, error) {
 
 	return ostreeTransport, registry, tag, nil
 }
+
+// MakeOstreeReference does its level best to take a container image
+// reference and turn it into an ostree reference.  If there is no ostree
+// transport present, it will add "ostree-unverified-registry".
+func MakeOstreeReference(img string) (string, error) {
+	_, _, _, err := ParseOstreeReference(img)
+	if err == nil {
+		return img, nil
+	}
+
+	img = fmt.Sprintf("ostree-unverified-registry:%s", img)
+	_, _, _, err = ParseOstreeReference(img)
+	log.Debugf("Making reference %s", img)
+	return img, err
+}

--- a/pkg/image/registry.go
+++ b/pkg/image/registry.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/containers/image/v5/docker/reference"
+	"github.com/containers/image/v5/transports/alltransports"
 	log "github.com/sirupsen/logrus"
 	"strings"
 )
@@ -42,49 +43,87 @@ func AddDefaultRegistry(imageToChange string, registry string) (string, error) {
 	return toAdd, nil
 }
 
-// ParseOstreeReference returns two strings.  First, the ostree
-// reference without a tag.  Second, a reference that is usable
-// by Podman compatible container runtimes.  For example,
+// ParseOstreeReference returns three strings: the ostree transport, registry,
+// and tag for an ostree container image.  For example,
 // "ostree-unverified-image:container-registry.oracle.com/olcne/ock-ostree:1.30"
-// returns "ostree-unverified-image:container-registry.oracle.com/olcne/ock-ostree"
-// and container-registry.oracle.com/olcne/ock-ostree:1.30
-func ParseOstreeReference(img string) (string, string, error) {
+// returns "ostree-unverified-image", "container-registry.oracle.com/olcne/ock-ostree"
+// and "1.30".  It is not necessary that a tag is present, but all the rest of the
+// fields are reuired.
+func ParseOstreeReference(img string) (string, string, string, error) {
 	// Important stuff is colon delimited.
 	fields := strings.Split(img, ":")
 
-	// At the very least there needs to be a registry
-	// and a tag.  More, actually, but that is all checked
-	// later on.
+	// At the very least there needs to be a transport and a registry.
 	if len(fields) < 2 {
-		return "", "", fmt.Errorf("%s is not a valid ostree image reference", img)
+		return "", "", "", fmt.Errorf("%s is not a valid ostree image reference", img)
 	}
 
-	switch fields[0] {
+	ostreeTransport := fields[0]
+	switch ostreeTransport {
 	case "ostree-unverified-image", "ostree-image-signed":
 		fields = fields[1:]
+		ostreeTransport = fmt.Sprintf("%s:%s", ostreeTransport, fields[0])
 		switch fields[0] {
 		case "registry":
 			fields = fields[1:]
 		case "docker":
 			// strip off the "//"
+			ostreeTransport = fmt.Sprintf("%s://", ostreeTransport)
+			fields = fields[1:]
 			fields[0] = fields[0][2:]
 		default:
-			return "", "", fmt.Errorf("%s is not a valid ostree image reference", img)
+			return "", "", "", fmt.Errorf("%s is not a valid ostree image reference", img)
 		}
 	case "ostree-unverified-registry":
+		ostreeTransport = fields[0]
 		fields = fields[1:]
 	case "ostree-remote-image":
-		if len(fields) < 3 {
-			return "", "", fmt.Errorf("%s is not a valid ostree image reference", img)
+		if len(fields) < 4 {
+			return "", "", "", fmt.Errorf("%s is not a valid ostree image reference", img)
 		}
-		fields = fields[2:]
+
+		ostreeTransport = fmt.Sprintf("%s:%s", ostreeTransport, fields[1])
+		switch fields[2] {
+		case "registry":
+			ostreeTransport = fmt.Sprintf("%s:%s", ostreeTransport, fields[2])
+		case "docker":
+			ostreeTransport = fmt.Sprintf("%s:docker://", ostreeTransport)
+			if !strings.HasPrefix(fields[3], "//") {
+				return "", "", "", fmt.Errorf("%s is not a valid ostree image reference", img)
+			}
+			fields[3] = fields[3][2:]
+		}
+		fields = fields[3:]
 	default:
-		return "", "", fmt.Errorf("%s is not a valid ostree image reference", img)
+		return "", "", "", fmt.Errorf("%s is not a valid ostree image reference", img)
 	}
 
-	// Hack the tag off the reference for the ostree image
-	imgIdx := strings.LastIndex(img, ":")
-	ostreeImg := img[:imgIdx]
+	// Parse the registry reference.  Stick a fake transport on top to
+	// satisfy the parser
+	registry := fmt.Sprintf("docker://%s", strings.Join(fields, ":"))
+	ref, err := alltransports.ParseImageName(registry)
+	if err != nil {
+		return "", "", "", err
+	}
 
-	return ostreeImg, strings.Join(fields, ":"), nil
+	dockerRef := ref.DockerReference()
+	if dockerRef == nil {
+		return "", "", "", fmt.Errorf("%s is not a valid ostree image reference", img)
+	}
+
+	tag := ""
+	registry = dockerRef.Name()
+	nameTag, ok := dockerRef.(reference.NamedTagged)
+	if ok {
+		tag = nameTag.Tag()
+	}
+
+	// If no tag is present, the docker reference will give
+	// back the tag "latest".  If the input image was not explicitly
+	// tagged that way, then set the tag to the empty string
+	if tag == "latest" && !strings.HasSuffix(img, ":latest") {
+		tag = ""
+	}
+
+	return ostreeTransport, registry, tag, nil
 }

--- a/pkg/image/registry_test.go
+++ b/pkg/image/registry_test.go
@@ -1,0 +1,31 @@
+// Copyright (c) 2024, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package image
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseOstreeReference(t *testing.T) {
+	cases := [][]string{
+		[]string{"ostree-unverified-image:registry:container-registry.oracle.com/olcne/ock-ostree", "ostree-unverified-image:registry", "container-registry.oracle.com/olcne/ock-ostree", ""},
+		[]string{"ostree-unverified-image:docker://container-registry.oracle.com/olcne/ock-ostree", "ostree-unverified-image:docker://", "container-registry.oracle.com/olcne/ock-ostree", ""},
+		[]string{"ostree-unverified-image:registry:container-registry.oracle.com/olcne/ock-ostree:1.30", "ostree-unverified-image:registry", "container-registry.oracle.com/olcne/ock-ostree", "1.30"},
+		[]string{"ostree-unverified-image:docker://container-registry.oracle.com/olcne/ock-ostree:1.30", "ostree-unverified-image:docker://", "container-registry.oracle.com/olcne/ock-ostree", "1.30"},
+		[]string{"ostree-unverified-registry:container-registry.oracle.com/olcne/ock-ostree", "ostree-unverified-registry", "container-registry.oracle.com/olcne/ock-ostree", ""},
+		[]string{"ostree-unverified-registry:container-registry.oracle.com/olcne/ock-ostree:1.30", "ostree-unverified-registry", "container-registry.oracle.com/olcne/ock-ostree", "1.30"},
+		[]string{"ostree-remote-image:remotename:docker://container-registry.oracle.com/olcne/ock-ostree", "ostree-remote-image:remotename:docker://", "container-registry.oracle.com/olcne/ock-ostree", ""},
+		[]string{"ostree-remote-image:remotename:docker://container-registry.oracle.com/olcne/ock-ostree:1.30", "ostree-remote-image:remotename:docker://", "container-registry.oracle.com/olcne/ock-ostree", "1.30"},
+	}
+
+	for i, c := range cases {
+		xport, ref, tag, err := ParseOstreeReference(c[0])
+		assert.Equal(t, c[1], xport, "%d: %+v", i, err)
+		assert.Equal(t, c[2], ref, "%d: %+v", i, err)
+		assert.Equal(t, c[3], tag, "%d: %+v", i, err)
+		assert.Nil(t, err)
+	}
+}

--- a/test/bats/image/image.bats
+++ b/test/bats/image/image.bats
@@ -12,25 +12,25 @@ setup_file() {
 }
 
 @test "ocne image create --type ostree" {
-	ocne image create --type ostree > /tmp/out-ostree 2>&1
-	img=$(grep "Saved image to" /tmp/out-ostree | awk '{print $NF}' | tr -d '"')
+	run -0 ocne image create --type ostree
+	img=$(echo "$output" | grep "Saved image to" | awk '{print $NF}' | tr -d '"')
 	if [ ! -f $img ]; then
 		echo "missing image file $img"
 		exit 1
 	fi
 	echo "image file created is $img"
-	rm -rf $img /tmp/out-ostree
+	rm -rf $img
 }
 
 @test "ocne image create -a arm64 and amd64" {
 	for arch in amd64 arm64; do
-		ocne image create -a $arch > /tmp/out-$arch 2>&1
-		img=$(tail -n1 /tmp/out-$arch | awk '{print $NF}' | tr -d '"')
+		run -0 ocne image create -a $arch
+		img=$(echo "$output" | tail -n1 | awk '{print $NF}' | tr -d '"')
 		if [ ! -f $img ]; then
 			echo "missing image file $img"
 			exit 1
 		fi
 		echo "image file created is $img"
-		rm -rf $img /tmp/out-$arch
+		rm -rf $img
 	done
 }

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -16,7 +16,7 @@ TEST_K8S_VERSION=${TEST_K8S_VERSION:=""}
 # Default to the latest k8s version
 export K8S_VERSION_FLAG=""
 if [[ $TEST_K8S_VERSION != "" ]]; then
-  export K8S_VERSION_FLAG="--version ${TEST_K8S_VERSION}"
+  export K8S_VERSION_FLAG="--version=${TEST_K8S_VERSION}"
 fi
 
 # This silly thing makes mktemp work on Mac and Linux


### PR DESCRIPTION
Changes how ostree image parsing works to handle more cases and split the image URI into more useful chunks.  The places where ostree images are consumed, especially when mixed with the syntax required for skopeo, have been updated to take advantage of this.