### PR TITLE
Fix case where cluster-info.out file was not displaying full output when a redacted dump was used

### DIFF
--- a/cmd/cluster/dump/dump.go
+++ b/cmd/cluster/dump/dump.go
@@ -5,11 +5,11 @@ package dump
 
 import (
 	"fmt"
-	"github.com/spf13/cobra"
 	"github.com/oracle-cne/ocne/cmd/constants"
 	"github.com/oracle-cne/ocne/pkg/cmdutil"
 	"github.com/oracle-cne/ocne/pkg/commands/cluster/dump"
 	"github.com/oracle-cne/ocne/pkg/util/strutil"
+	"github.com/spf13/cobra"
 	"strings"
 )
 

--- a/pkg/commands/cluster/dump/capture/capture.go
+++ b/pkg/commands/cluster/dump/capture/capture.go
@@ -5,7 +5,6 @@ package capture
 
 import (
 	"bufio"
-	"github.com/oracle-cne/ocne/pkg/commands/cluster/dump/capture/sanitize"
 	"io"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
@@ -101,16 +100,6 @@ func CaptureAllResources(cp CaptureParams) error {
 	cs.wg.Wait()
 
 	return nil
-}
-
-// PutIntoNodeNamesIfNotPresent populates the node map with a given node name
-func PutIntoNodeNamesIfNotPresent(inputKey string) {
-	sanitize.KnownNodeNamesMutex.Lock()
-	_, ok := sanitize.KnownNodeNames[inputKey]
-	if !ok {
-		sanitize.KnownNodeNames[inputKey] = sanitize.RedactionPrefix + sanitize.GetShortSha256Hash(inputKey)
-	}
-	sanitize.KnownNodeNamesMutex.Unlock()
 }
 
 // read each line, do not sanitize it and write to writer

--- a/pkg/commands/cluster/dump/capture/capture.go
+++ b/pkg/commands/cluster/dump/capture/capture.go
@@ -5,6 +5,7 @@ package capture
 
 import (
 	"bufio"
+	"github.com/oracle-cne/ocne/pkg/commands/cluster/dump/capture/sanitize"
 	"io"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
@@ -20,10 +21,6 @@ const (
 
 	// Throttle the go routines so Kuberenetes API server doesn't get overloaded
 	maxGoRoutines = 50
-
-	// File containing a map from redacted values to their original values
-	RedactionPrefix = "REDACTED-"
-	RedactionMap    = "sensitive-do-not-share-redaction-map.csv"
 )
 
 var containerStartLog = "==== START logs for container %s of pod %s/%s ====\n"
@@ -108,12 +105,12 @@ func CaptureAllResources(cp CaptureParams) error {
 
 // PutIntoNodeNamesIfNotPresent populates the node map with a given node name
 func PutIntoNodeNamesIfNotPresent(inputKey string) {
-	knownNodeNamesMutex.Lock()
-	_, ok := KnownNodeNames[inputKey]
+	sanitize.KnownNodeNamesMutex.Lock()
+	_, ok := sanitize.KnownNodeNames[inputKey]
 	if !ok {
-		KnownNodeNames[inputKey] = RedactionPrefix + GetShortSha256Hash(inputKey)
+		sanitize.KnownNodeNames[inputKey] = sanitize.RedactionPrefix + sanitize.GetShortSha256Hash(inputKey)
 	}
-	knownNodeNamesMutex.Unlock()
+	sanitize.KnownNodeNamesMutex.Unlock()
 }
 
 // read each line, do not sanitize it and write to writer

--- a/pkg/commands/cluster/dump/capture/clusterinfo.go
+++ b/pkg/commands/cluster/dump/capture/clusterinfo.go
@@ -6,9 +6,10 @@ package capture
 import (
 	"bufio"
 	"bytes"
+	"github.com/oracle-cne/ocne/pkg/commands/cluster/dump/capture/sanitize"
+	"github.com/oracle-cne/ocne/pkg/commands/cluster/info"
 	log "github.com/sirupsen/logrus"
 	"k8s.io/client-go/kubernetes"
-	"github.com/oracle-cne/ocne/pkg/commands/cluster/info"
 	"os"
 	"path/filepath"
 )
@@ -46,7 +47,7 @@ func CaptureClusterInfo(kubeClient kubernetes.Interface, outDir string, skipReda
 	defer fOut.Close()
 
 	if !skipRedact {
-		sanitizeLines(bytes.NewReader(b.Bytes()), bufio.NewWriter(fOut))
+		sanitize.SanitizeLines(bytes.NewReader(b.Bytes()), bufio.NewWriter(fOut))
 	} else {
 		writeWithoutSanitize(bytes.NewReader(b.Bytes()), bufio.NewWriter(fOut))
 	}

--- a/pkg/commands/cluster/dump/capture/k8sresource.go
+++ b/pkg/commands/cluster/dump/capture/k8sresource.go
@@ -7,13 +7,14 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/oracle-cne/ocne/pkg/commands/cluster/dump/capture/gvr"
+	"github.com/oracle-cne/ocne/pkg/commands/cluster/dump/capture/sanitize"
 	log "github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
-	"github.com/oracle-cne/ocne/pkg/commands/cluster/dump/capture/gvr"
 	"os"
 	"path/filepath"
 	"strings"
@@ -114,7 +115,7 @@ func writeJSONToFile(v interface{}, namespace, resourceFile, outDir string, reda
 
 	resJSON, _ := json.MarshalIndent(v, JSONPrefix, JSONIndent)
 	if redact {
-		_, err = f.WriteString(SanitizeString(string(resJSON), nil))
+		_, err = f.WriteString(sanitize.SanitizeString(string(resJSON), nil))
 	} else {
 		_, err = f.WriteString(string(resJSON))
 	}

--- a/pkg/commands/cluster/dump/capture/pod.go
+++ b/pkg/commands/cluster/dump/capture/pod.go
@@ -7,11 +7,12 @@ import (
 	"bufio"
 	"context"
 	"fmt"
+	"github.com/oracle-cne/ocne/pkg/commands/cluster/dump/capture/sanitize"
+	"github.com/oracle-cne/ocne/pkg/k8s"
 	log "github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
-	"github.com/oracle-cne/ocne/pkg/k8s"
 	"os"
 	"path/filepath"
 	"strings"
@@ -89,7 +90,7 @@ func CapturePodLog(kubeClient kubernetes.Interface, outDir, namespace string, po
 			reader := bufio.NewScanner(podLog)
 			f.WriteString(fmt.Sprintf(containerStartLog, contName, namespace, podName))
 			for reader.Scan() {
-				f.WriteString(SanitizeString(reader.Text()+"\n", nil))
+				f.WriteString(sanitize.SanitizeString(reader.Text()+"\n", nil))
 			}
 			f.WriteString(fmt.Sprintf(containerEndLog, contName, namespace, podName))
 			return nil

--- a/pkg/commands/cluster/dump/capture/sanitize/sanitize.go
+++ b/pkg/commands/cluster/dump/capture/sanitize/sanitize.go
@@ -236,3 +236,13 @@ func SanitizeLines(reader io.Reader, writer io.Writer) error {
 	bufWriter.Flush()
 	return nil
 }
+
+// PutIntoNodeNamesIfNotPresent populates the node map with a given node name
+func PutIntoNodeNamesIfNotPresent(inputKey string) {
+	KnownNodeNamesMutex.Lock()
+	defer KnownNodeNamesMutex.Unlock()
+	_, ok := KnownNodeNames[inputKey]
+	if !ok {
+		KnownNodeNames[inputKey] = RedactionPrefix + GetShortSha256Hash(inputKey)
+	}
+}

--- a/pkg/commands/cluster/dump/capture/sanitize/sanitize_test.go
+++ b/pkg/commands/cluster/dump/capture/sanitize/sanitize_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2024, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
-package capture
+package sanitize
 
 import (
 	"encoding/csv"

--- a/pkg/commands/cluster/dump/cluster.go
+++ b/pkg/commands/cluster/dump/cluster.go
@@ -5,11 +5,12 @@ package dump
 
 import (
 	"fmt"
-	"k8s.io/client-go/dynamic"
-	"k8s.io/client-go/kubernetes"
 	"github.com/oracle-cne/ocne/pkg/commands/cluster/dump/capture"
+	"github.com/oracle-cne/ocne/pkg/commands/cluster/dump/capture/sanitize"
 	"github.com/oracle-cne/ocne/pkg/k8s"
 	"github.com/oracle-cne/ocne/pkg/util/strutil"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
 	"os"
 	"path/filepath"
 )
@@ -68,7 +69,7 @@ func populateNodeMap(cli kubernetes.Interface) error {
 		return err
 	}
 	for _, node := range nodeList.Items {
-		capture.PutIntoNodeNamesIfNotPresent(node.Name)
+		sanitize.PutIntoNodeNamesIfNotPresent(node.Name)
 	}
 	return nil
 }

--- a/pkg/commands/cluster/dump/node.go
+++ b/pkg/commands/cluster/dump/node.go
@@ -5,6 +5,7 @@ package dump
 
 import (
 	"fmt"
+	"github.com/oracle-cne/ocne/pkg/commands/cluster/dump/capture/sanitize"
 	"os"
 	"path/filepath"
 	"sync"
@@ -13,7 +14,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
 
-	"github.com/oracle-cne/ocne/pkg/commands/cluster/dump/capture"
 	"github.com/oracle-cne/ocne/pkg/constants"
 	"github.com/oracle-cne/ocne/pkg/k8s"
 	"github.com/oracle-cne/ocne/pkg/k8s/client"
@@ -97,7 +97,7 @@ func dumpNodes(o Options, kubeClient kubernetes.Interface) error {
 			if o.SkipRedact {
 				outDir = filepath.Join(o.OutDir, "nodes", p.NodeName)
 			} else {
-				outDir = filepath.Join(o.OutDir, "nodes", capture.RedactionPrefix+capture.GetShortSha256Hash(p.NodeName))
+				outDir = filepath.Join(o.OutDir, "nodes", sanitize.RedactionPrefix+sanitize.GetShortSha256Hash(p.NodeName))
 			}
 
 			// Dump the node using a pod.  Just log if error, it is not fatal
@@ -105,7 +105,7 @@ func dumpNodes(o Options, kubeClient kubernetes.Interface) error {
 				log.Errorf("Error dumping node %s: %s", p.NodeName, err.Error())
 			}
 			if !o.SkipRedact {
-				if err := capture.SanitizeFilesInDirTree(outDir); err != nil {
+				if err := sanitize.SanitizeFilesInDirTree(outDir); err != nil {
 					log.Errorf("Error accessing files in directory %s: %s.  Manually delete this directory and its contents, it may have sensitive data", outDir, err.Error())
 				}
 			}

--- a/pkg/commands/cluster/info/info.go
+++ b/pkg/commands/cluster/info/info.go
@@ -181,7 +181,7 @@ func getNodePath(outDir string, nodeName string) (string, error) {
 	sanitizedPath := filepath.Join(outDir, "nodes", sanitize.RedactionPrefix+sanitize.GetShortSha256Hash(nodeName))
 	_, err = os.Stat(sanitizedPath)
 	if err == nil {
-		return unSanitizedPath, nil
+		return sanitizedPath, nil
 	}
 	return "", fmt.Errorf("A valid nodePath for a node was not found in the cluster dump")
 }

--- a/pkg/commands/cluster/info/info.go
+++ b/pkg/commands/cluster/info/info.go
@@ -147,9 +147,9 @@ func extractNodeInfo(skipNodes bool, outDir string, nodeName string) (*nodeDumpD
 	unSanitizedPath := filepath.Join(outDir, "nodes", nodeName)
 	sanitizedPath := filepath.Join(outDir, "nodes", sanitize.RedactionPrefix+sanitize.GetShortSha256Hash(nodeName))
 	if _, err := os.Stat(sanitizedPath); err == nil {
-		nodeDir = unSanitizedPath
-	} else if _, err2 := os.Stat(unSanitizedPath); err == nil {
 		nodeDir = sanitizedPath
+	} else if _, err2 := os.Stat(unSanitizedPath); err2 == nil {
+		nodeDir = unSanitizedPath
 	} else if os.IsNotExist(err) && os.IsNotExist(err2) {
 		return nil, nil
 	} else if os.IsNotExist(err) && !os.IsNotExist(err2) {

--- a/pkg/commands/cluster/info/info.go
+++ b/pkg/commands/cluster/info/info.go
@@ -4,12 +4,13 @@
 package info
 
 import (
-	"io"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/client-go/kubernetes"
+	"github.com/oracle-cne/ocne/pkg/commands/cluster/dump/capture"
 	"github.com/oracle-cne/ocne/pkg/constants"
 	"github.com/oracle-cne/ocne/pkg/k8s"
 	"github.com/oracle-cne/ocne/pkg/k8s/client"
+	"io"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
 	"os"
 	"path/filepath"
 )
@@ -143,7 +144,9 @@ func validate(o *Options) error {
 func extractNodeInfo(skipNodes bool, outDir string, nodeName string) (*nodeDumpData, error) {
 	nodeDir := filepath.Join(outDir, "nodes", nodeName)
 	_, err := os.Stat(nodeDir)
-	if os.IsNotExist(err) {
+	redactedNodeDir := filepath.Join(capture.RedactionPrefix + capture.GetShortSha256Hash(nodeName))
+	_, err2 := os.Stat(redactedNodeDir)
+	if os.IsNotExist(err) && os.IsNotExist(err2) {
 		return nil, nil
 	}
 	if err != nil {

--- a/pkg/commands/cluster/info/info.go
+++ b/pkg/commands/cluster/info/info.go
@@ -143,6 +143,7 @@ func validate(o *Options) error {
 
 // extractNodeInfo extracts info from node dump files.  If the node directory doesn't exist then return nil
 func extractNodeInfo(skipNodes bool, outDir string, nodeName string) (*nodeDumpData, error) {
+	// This checks to see both filepaths, covering the cases where a redacted dump has occurred and when a non-redacted dump has occurred
 	var nodeDir string
 	unSanitizedPath := filepath.Join(outDir, "nodes", nodeName)
 	sanitizedPath := filepath.Join(outDir, "nodes", sanitize.RedactionPrefix+sanitize.GetShortSha256Hash(nodeName))


### PR DESCRIPTION
In this PR, I refactored some of the sanitization code in order to fix the case where the cluster-info.out file was not displaying its full output when a redacted cluster dump was being used to generate it. 

Output of cluster-info.out file when a redacted dump is ran 
```
Cluster Summary:
  control plane nodes: 1
  worker nodes: 0
  nodes with available updates: 0

Nodes:
  Name                  Role            State   Version         Update Available
  ----                  ----            -----   -------         ----------------
  REDACTED-dd54744c     control plane   Ready   v1.29.3+3.el8   false


Node: REDACTED-dd54744c
  Registry and tag for ostree patch images:
    registry: sample-registry
    tag: 1.29
    transport: ostree-unverified-registry
  Ostree deployments:
...
```
Output of cluster-info.out file when a non-redacted dump is ran
```
Cluster Summary:
  control plane nodes: 1
  worker nodes: 0
  nodes with available updates: 0

Nodes:
  Name                  Role            State   Version         Update Available
  ----                  ----            -----   -------         ----------------
  my-control-plane  control plane   Ready   v1.29.3+3.el8   false


Node: my-control-plane
  Registry and tag for ostree patch images:
    registry: sample registry
    tag: 1.29
    transport: ostree-unverified-registry
  Ostree deployments:
...
```