### PR TITLE
Add doc links to the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,32 +4,11 @@ The Oracle Linux Cloud Native Environment Command Line Interface (CLI) is a
 tool that manages the lifecycle of Kubernetes clusters and the applications
 running inside those clusters.
 
-## Installation
+## Documentation
 
-The CLI is available for Oracle Linux 8 and Oracle Linux 9.  It can be
-installed from repositories on the [Oracle Linux YUM Repository](https://yum.oracle.com).  It can also be built from this source code.
+For overall documentation, see [Oracle Linux Cloud Native Environment](https://docs.oracle.com/en/operating-systems/olcne/).  
 
-### Oracle Linux 8
-
-Perform the following steps to install the Oracle Cloud Native Environment
-YUM repository, enable it, and install the CLI.
-
-```
-dnf install -y oracle-ocne-release-el8
-dnf config-manager --enable ol8_ocne
-dnf install -y ocne
-```
-
-### Oracle Linux 9
-
-Installing the CLI on Oracle Linux 9 can be done with the following
-instructions.
-
-```
-dnf install -y oracle-ocne-release-el9
-dnf config-manager --enable ol9_ocne
-dnf install -y ocne
-```
+To start using the CLI, see [Quick Start for Release 2.0](https://docs.oracle.com/en/operating-systems/olcne/2.0/quickstart/intro.html).
 
 ### Building yourself
 


### PR DESCRIPTION
The ocne repo README.md file is missing a link to the Oracle OCNE 2.0 documentation. Also, the quick start steps in the README.md do not work unless you set up prerequisites. Do the following:

1. Add link to the Oracle OCNE 2.0 documentation
2. Add a link to the libvirt quickstart in that documentation.  This has all the prerequisite steps for run the CLI.
3. Remove the setup commands

NOTE: You can select "view file" in the .. menu when viewing README.md.  You  will see the doc links then click on them.