### PR TITLE
Fix regression were provider was possible ignored in cluster delete

### DIFF
--- a/cmd/cluster/delete/delete.go
+++ b/cmd/cluster/delete/delete.go
@@ -50,8 +50,8 @@ func NewCmd() *cobra.Command {
 	cmd.Flags().StringVarP(&config.KubeConfig, constants.FlagKubeconfig, constants.FlagKubeconfigShort, "", constants.FlagKubeconfigHelp)
 	cmd.Flags().StringVarP(&clusterConfigPath, flagConfig, flagConfigShort, "", flagConfigHelp)
 	cmd.Flags().StringVarP(&config.Providers.Libvirt.SessionURI, constants.FlagSshURI, constants.FlagSshURIShort, "", constants.FlagSshURIHelp)
-	cmd.Flags().StringVarP(&clusterConfig.Name, constants.FlagClusterName, constants.FlagClusterNameShort, "ocne", constants.FlagClusterNameHelp)
-	cmd.Flags().StringVarP(&clusterConfig.Provider, constants.FlagProviderName, constants.FlagProviderNameShort, "libvirt", constants.FlagProviderNameHelp)
+	cmd.Flags().StringVarP(&clusterConfig.Name, constants.FlagClusterName, constants.FlagClusterNameShort, "", constants.FlagClusterNameHelp)
+	cmd.Flags().StringVarP(&clusterConfig.Provider, constants.FlagProviderName, constants.FlagProviderNameShort, "", constants.FlagProviderNameHelp)
 
 	return cmd
 }
@@ -93,6 +93,13 @@ func RunCmd(cmd *cobra.Command) error {
 		if err != nil {
 			return err
 		}
+	}
+
+	if cc.Name == "" {
+		cc.Name = "ocne"
+	}
+	if cc.Provider == "" {
+		cc.Provider = "libvirt"
 	}
 
 	err = delete2.Delete(c, cc)


### PR DESCRIPTION
As part of https://github.com/oracle-cne/ocne/pull/8 there was a change in the order of evaluation for some cluster configuration options.  The necessary adaptations to cluster delete were not made, and as a result cluster delete would always use the libvirt provider.

Here's a demonstration that this new code works:
```
[opc@dkrasins-dev-ol9 ocne]$ ./out/linux_amd64/ocne cluster delete -c capi.yaml
INFO[2024-09-30T19:14:06Z] Deleting file /home/opc/.kube/kubeconfig.ocne.local 
INFO[2024-09-30T19:14:06Z] Deleting file /home/opc/.kube/kubeconfig.ocne.vm 
INFO[2024-09-30T19:18:59Z] Installing cert-manager into cert-manager: ok 
INFO[2024-09-30T19:19:01Z] Installing core-capi into capi-system: ok 
INFO[2024-09-30T19:19:04Z] Installing capoci into cluster-api-provider-oci-system: ok 
INFO[2024-09-30T19:19:06Z] Installing bootstrap-capi into capi-kubeadm-bootstrap-system: ok 
INFO[2024-09-30T19:19:08Z] Installing control-plane-capi into capi-kubeadm-control-plane-system: ok 
INFO[2024-09-30T19:19:38Z] Waiting for OCI Cluster API Controllers: ok 
INFO[2024-09-30T19:19:58Z] Waiting for Core Cluster API Controllers: ok 
INFO[2024-09-30T19:20:28Z] Waiting for Kubadm Boostrap Cluster API Controllers: ok 
INFO[2024-09-30T19:20:48Z] Waiting for Kubadm Control Plane Cluster API Controllers: ok 
INFO[2024-09-30T19:20:48Z] Migrating Cluster API resources to bootstrap cluster 
INFO[2024-09-30T19:20:51Z] Deleting Cluster ocne/ocne       
```