### PR TITLE
Set cluster name and number of control plane nodes from cluster configuration file for the "ocne cluster template" command.

### DIFF
--- a/cmd/cluster/template/template.go
+++ b/cmd/cluster/template/template.go
@@ -6,12 +6,12 @@ package template
 import (
 	"fmt"
 
-	"github.com/spf13/cobra"
 	"github.com/oracle-cne/ocne/cmd/constants"
 	"github.com/oracle-cne/ocne/pkg/cmdutil"
 	"github.com/oracle-cne/ocne/pkg/commands/cluster/template"
 	"github.com/oracle-cne/ocne/pkg/config/types"
 	pkgconst "github.com/oracle-cne/ocne/pkg/constants"
+	"github.com/spf13/cobra"
 )
 
 const (
@@ -28,9 +28,7 @@ var clusterConfigPath string
 
 var opts = template.TemplateOptions{
 	ClusterConfig: types.ClusterConfig{
-		Name:              "ocne",
-		ControlPlaneNodes: pkgconst.ControlPlaneNodes,
-		WorkerNodes:       pkgconst.WorkerNodes,
+		WorkerNodes: pkgconst.WorkerNodes,
 	},
 }
 
@@ -65,6 +63,16 @@ func RunCmd(cmd *cobra.Command) error {
 	// match the k8s version
 	if cc.OsTag == pkgconst.KubeVersion && cc.KubeVersion != pkgconst.KubeVersion {
 		cc.OsTag = cc.KubeVersion
+	}
+
+	// if cluster name is empty, then default it to ocne
+	if cc.Name == "" {
+		cc.Name = "ocne"
+	}
+
+	// if number of control plane nodes is 0, then default it to 1
+	if cc.ControlPlaneNodes == 0 {
+		cc.ControlPlaneNodes = pkgconst.ControlPlaneNodes
 	}
 
 	opts.Config = *c

--- a/cmd/cluster/template/template.go
+++ b/cmd/cluster/template/template.go
@@ -4,6 +4,7 @@
 package template
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/oracle-cne/ocne/cmd/constants"
@@ -73,6 +74,10 @@ func RunCmd(cmd *cobra.Command) error {
 	// if number of control plane nodes is 0, then default it to 1
 	if cc.ControlPlaneNodes == 0 {
 		cc.ControlPlaneNodes = pkgconst.ControlPlaneNodes
+	}
+
+	if cc.Provider == "oci" && cc.ControlPlaneNodes % 2 == 0 {
+		return errors.New("the number of control plane nodes must be odd")
 	}
 
 	opts.Config = *c

--- a/cmd/cluster/template/template.go
+++ b/cmd/cluster/template/template.go
@@ -4,7 +4,6 @@
 package template
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/oracle-cne/ocne/cmd/constants"
@@ -74,10 +73,6 @@ func RunCmd(cmd *cobra.Command) error {
 	// if number of control plane nodes is 0, then default it to 1
 	if cc.ControlPlaneNodes == 0 {
 		cc.ControlPlaneNodes = pkgconst.ControlPlaneNodes
-	}
-
-	if cc.Provider == "oci" && cc.ControlPlaneNodes % 2 == 0 {
-		return errors.New("the number of control plane nodes must be odd")
 	}
 
 	opts.Config = *c

--- a/doc/manpages/ocne-config.yaml.md
+++ b/doc/manpages/ocne-config.yaml.md
@@ -22,6 +22,7 @@ SCHEMA
 name: ocne
 
 # The number of control plane nodes to spawn
+# When the provider is set to oci, the number of control plane nodes must be odd
 controlPlaneNodes: 1
 
 # The number of worker nodes to spawn

--- a/pkg/cluster/template/capi-oci.go
+++ b/pkg/cluster/template/capi-oci.go
@@ -4,6 +4,7 @@
 package template
 
 import (
+	"errors"
 	"fmt"
 	"regexp"
 	"strings"
@@ -258,6 +259,10 @@ func GetOciTemplate(config *types.Config, clusterConfig *types.ClusterConfig) (s
 
 	if err != nil {
 		return "", err
+	}
+
+	if clusterConfig.ControlPlaneNodes % 2 == 0 {
+		return "", errors.New("the number of control plane nodes must be odd")
 	}
 
 	// Get the Kubernetes version configuration


### PR DESCRIPTION
Example cluster configuration file: capi.yaml
```shell
provider: oci
name: pras-cluster
workerNodes: 3
controlPlaneNodes: 3
clusterDefinition: mycluster.oci
.....
.....
```
Create a new ClusterAPI yaml using
```shell
ocne cluster template -c capi.yaml > mycluster.oci
```

Cluster name correctly set to "pras-cluster" instead of "ocne". Other references to "ocne" that correctly updated as well.
```shell
$ grep --context=10 clusterName mycluster.oci
            cloud-provider: external
            provider-id: oci://{{ ds["id"] }}
            volume-plugin-dir: "/var/lib/kubelet/volumeplugins"
---
apiVersion: cluster.x-k8s.io/v1beta1
kind: MachineDeployment
metadata:
  name: "pras-cluster-md-0"
  namespace: "pras-ns"
spec:
  clusterName: "pras-cluster"
  replicas: 3
  selector:
    matchLabels:
  template:
    spec:
      clusterName: "pras-cluster"
      version: "1.30.3"
      bootstrap:
        configRef:
          name: "pras-cluster-md-0"
          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
          kind: KubeadmConfigTemplate
      infrastructureRef:
        name: "pras-cluster-md-0"
        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
        kind: OCIMachineTemplate
``` 
Replicas for control plane nodes correctly set to 3.
```shell
$ grep --context=5 replicas mycluster.oci-test 
metadata:
  name: "pras-cluster-control-plane"
  namespace: "pras-ns"
spec:
  version: "1.30.3"
  replicas: 3
  machineTemplate:
    infrastructureRef:
      kind: OCIMachineTemplate
      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
      name: "pras-cluster-control-plane"
--
metadata:
  name: "pras-cluster-md-0"
  namespace: "pras-ns"
spec:
  clusterName: "pras-cluster"
  replicas: 3
  selector:
    matchLabels:
  template:
    spec:
      clusterName: "pras-cluster"
```

Correct number of control planes are getting created
```shell
~ $ export KUBECONFIG=~/.kube/kubeconfig.pras-cluster 
~ $ kubectl get nodes -o wide
NAME                               STATUS   ROLES           AGE   VERSION         INTERNAL-IP      EXTERNAL-IP   OS-IMAGE                   KERNEL-VERSION                      CONTAINER-RUNTIME
pras-cluster-control-plane-hlk7s   Ready    control-plane   14h   v1.30.3+1.el8   100.101.68.155   <none>        Oracle Linux Server 8.10   5.15.0-209.161.7.2.el8uek.aarch64   cri-o://1.30.3
pras-cluster-control-plane-tnfrz   Ready    control-plane   14h   v1.30.3+1.el8   100.101.68.45    <none>        Oracle Linux Server 8.10   5.15.0-209.161.7.2.el8uek.aarch64   cri-o://1.30.3
pras-cluster-control-plane-wrt45   Ready    control-plane   14h   v1.30.3+1.el8   100.101.68.226   <none>        Oracle Linux Server 8.10   5.15.0-209.161.7.2.el8uek.aarch64   cri-o://1.30.3
pras-cluster-md-0-hw2jg-6sqxf      Ready    <none>          14h   v1.30.3+1.el8   100.101.68.125   <none>        Oracle Linux Server 8.10   5.15.0-209.161.7.2.el8uek.x86_64    cri-o://1.30.3
pras-cluster-md-0-hw2jg-klzzn      Ready    <none>          14h   v1.30.3+1.el8   100.101.68.68    <none>        Oracle Linux Server 8.10   5.15.0-209.161.7.2.el8uek.x86_64    cri-o://1.30.3
pras-cluster-md-0-hw2jg-r947d      Ready    <none>          14h   v1.30.3+1.el8   100.101.68.228   <none>        Oracle Linux Server 8.10   5.15.0-209.161.7.2.el8uek.x86_64    cri-o://1.30.3
```  