### PR TITLE
Add VZ 1.6.11 CLI download instructions

### DIFF
--- a/doc/experimental/oam-to-kubernetes.md
+++ b/doc/experimental/oam-to-kubernetes.md
@@ -1,11 +1,32 @@
 # OAM to Kubernetes Mappings
 
-### Version: v0.0.1-draft
+### Version: v0.0.2-draft
+This document explains how to generate Kuberenetes YAML files from OAM-related resources that are running in a Kubernetes cluster.
 
-## Verrazzano CLI export command
+## Download Verrazzano 1.6.11 CLI
 Verrazzano provides a CLI command that you can use to facilitate the migration of an OAM application to be managed as a collection of Kubernetes objects.
+If you don't have the 1.6.11 CLI (or later), you need to download it to export the OAM resources to Kubernetes manfests.
 
-The command vz export oam will output the YAML for each Kubernetes object that was generated as a result of deploying an OAM application. The generated YAML is sanitized so that it can be used to deploy the application. Fields such as creationTimestamp, resourceVersion, uid, and status are not included in the output.
+Download the CLI for Linux-AMD as follows:
+```
+curl -LO https://github.com/verrazzano/verrazzano/releases/download/v1.6.11/verrazzano-1.6.11-linux-amd64.tar.gz
+tar xvf verrazzano-1.6.11-linux-amd64.tar.gz
+sudo cp verrazzano-1.6.11/bin/vz /usr/local/bin
+```
+
+Check the version:
+```
+vz version
+
+Version: v1.6.11
+BuildDate: 2024-02-29T20:12:32Z
+GitCommit: 1a31fa57c75d570220674b03f5297130bcecb311
+```
+
+## Run Verrazzano CLI export command
+The command vz export oam will output the YAML for each Kubernetes object that was generated as a result of deploying an OAM application.  
+The generated YAML is sanitized so that it can be used to deploy the application.  
+Fields such as creationTimestamp, resourceVersion, uid, and status are not included in the output.
 
 For example, the following CLI command exports the YAML from the hello-helidon OAM sample application.
 

--- a/doc/experimental/oam-to-kubernetes.md
+++ b/doc/experimental/oam-to-kubernetes.md
@@ -1,13 +1,14 @@
 # OAM to Kubernetes Mappings
 
 ### Version: v0.0.2-draft
-This document explains how to generate Kuberenetes YAML files from OAM-related resources that are running in a Kubernetes cluster.
+This document explains how to generate Kuberenetes YAML files from OAM-related objects that are running in a Kubernetes cluster.
 
-## Download Verrazzano 1.6.11 CLI
+## Installing Verrazzano 1.6.11 CLI on a Linux AMD64 machine
 Verrazzano provides a CLI command that you can use to facilitate the migration of an OAM application to be managed as a collection of Kubernetes objects.
-If you don't have the 1.6.11 CLI (or later), you need to download it to export the OAM resources to Kubernetes manfests.
+If you don't have the 1.6.11 CLI (or later), you need to download it, then use it to export the Kubernetes objects that were generated 
+for an OAM applications to Kubernetes YAML manifests.
 
-Download the CLI for Linux-AMD as follows:
+These instructions demonstrate installing the CLI on a Linux AMD64 machine:
 ```
 curl -LO https://github.com/verrazzano/verrazzano/releases/download/v1.6.11/verrazzano-1.6.11-linux-amd64.tar.gz
 tar xvf verrazzano-1.6.11-linux-amd64.tar.gz


### PR DESCRIPTION
Add VZ 1.6.11 CLI download instructions since it is needed to generate Kubernetes YAML manifests from cluster resources related to OAM.