### PR TITLE
add oci-instance-metadata-endpoint to noproxy

### DIFF
--- a/pkg/cluster/template/capi-oci.go
+++ b/pkg/cluster/template/capi-oci.go
@@ -130,7 +130,7 @@ fi
 
 func getExtraIgnition(confg *types.Config, clusterConfig *types.ClusterConfig) (string, error) {
 	// Accept proxy configuration
-	proxy, err := ignition.Proxy(&clusterConfig.Proxy, clusterConfig.ServiceSubnet, clusterConfig.PodSubnet)
+	proxy, err := ignition.Proxy(&clusterConfig.Proxy, clusterConfig.ServiceSubnet, clusterConfig.PodSubnet, constants.InstanceMetadata)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -39,6 +39,7 @@ const (
 	KubeAPIServerBindPortAlt = uint16(6444)
 	PodSubnet                = "10.244.0.0/16"
 	ServiceSubnet            = "10.96.0.0/12"
+	InstanceMetadata         = "169.254.169.254"
 	ContainerRegistry        = "container-registry.oracle.com"
 
 	CertKey = "tls.crt"


### PR DESCRIPTION
add oci-instance-metadata-endpoint to noproxy to fix ocid-populate.conf and kubeadm.yml