### PR TITLE
Increase keepalived liveness timeout to 1m to account for resource contention under load

### DIFF
--- a/pkg/cluster/ignition/virtual_ip.go
+++ b/pkg/cluster/ignition/virtual_ip.go
@@ -66,7 +66,7 @@ errorExit() {
 
 # update keepalived.conf/nginx.conf and restart keepalived.service/ocne-nginx.service if necessary
 refreshServices() {
-  NODES=$(KUBECONFIG=/etc/keepalived/kubeconfig kubectl --server=https://localhost:{{ .AltPort }} --tls-server-name=$(hostname) get nodes --request-timeout 1s --no-headers --selector 'node-role.kubernetes.io/control-plane' -o wide | awk -v OFS='\t\t' '{print $6}')
+  NODES=$(KUBECONFIG=/etc/keepalived/kubeconfig kubectl --server=https://localhost:{{ .AltPort }} --tls-server-name=$(hostname) get nodes --request-timeout 1m --no-headers --selector 'node-role.kubernetes.io/control-plane' -o wide | awk -v OFS='\t\t' '{print $6}')
   if [ $? -ne 0 ]; then
     return 0
   fi


### PR DESCRIPTION
Bump the `kubectl get node` to 1 minute.  Please see the linked issue for details