### PR TITLE
Document Verrazzano kube prometheus stack migration to catalog

### DIFF
--- a/doc/experimental/kube-prometheus-stack.md
+++ b/doc/experimental/kube-prometheus-stack.md
@@ -32,27 +32,170 @@ sed -i '/alertmanagerDefaultBaseImage:/d' overrides.yaml
 sed -i '/alertmanagerDefaultBaseImageRegistry:/d' overrides.yaml
 sed -i '/prometheusDefaultBaseImage:/d' overrides.yaml
 sed -i '/prometheusDefaultBaseImageRegistry:/d' overrides.yaml
+sed -i '/prometheusConfigReloader:/d' overrides.yaml 
 
 sed -i '/image:/,+3d' overrides.yaml
 sed -i '/thanosImage:/,+3d' overrides.yaml
 ```
-## Change the Prometheus PV Reclaim Policy
+## Change the Prometheus PV reclaim policy
 
 Change reclaim policy to **Retain**.  
 ```text
 # get the pv-name (VOLUME NAME)
-PV_NAME=$(kubectl --kubeconfig ~/paul-kubeconfig.yaml get pvc -n verrazzano-monitoring -o jsonpath='{.items[0].spec.volumeName}')
+PV_NAME=$(kubectl get pvc -n verrazzano-monitoring -o jsonpath='{.items[0].spec.volumeName}')
  
 # patch the PV 
 kubectl patch pv $PV_NAME -p '{"spec":{"persistentVolumeReclaimPolicy":"Retain"}}'
 ```
 
-## Uninstall Verrazzano kube-prometheus-stack (named prometheus-operator)
+## Uninstall Verrazzano kube-prometheus-stack, node export, and delete pvc
 ```text
-uninstall -n verrazzano-monitoring prometheus-operator  
+helm delete -n verrazzano-monitoring prometheus-operator  
+helm delete -n verrazzano-monitoring prometheus-node-exporter
 ```
 
-Update the existing installation:
+TODO - update ingress to use new service
+TODO - fix istio authorization policy for new sa.  Check all authorization policies.
+TODO - check network policies
+
+## Install kube-prometheus-stack from the catalog
 ```text
-ocne application update --release kube-state-metrics --namespace verrazzano-monitoring --version 2.8.2 --reset-values --values overrides.yaml
+ocne application install --name kube-prometheus-stack --namespace verrazzano-monitoring --values overrides.yaml
+```
+Wait until the prometheus server is running
+```text
+kubectl get pod -n verrazzano-monitoring prometheus-kube-prometheus-stack-prometheus-0 
+
+NAME                                            READY   STATUS    RESTARTS   AGE
+prometheus-kube-prometheus-stack-prometheus-0   3/3     Running   0          90s
+```
+
+## Migrate metrics data from old PV to new PV
+In this section, the Prometheus metrics will be copied from the old pv to the new pv.
+
+First scale down Prometheus.
+```text
+ scale sts -n  verrazzano-monitoring prometheus-kube-prometheus-stack-prometheus  --replicas=0
+```
+
+Create a pod YAML that mounts both pv's.
+```text
+cat > pod.yaml <<EOF
+apiVersion: v1
+kind: Pod
+metadata:
+  name: shared-pvc
+  namespace: verrazzano-monitoring
+  labels:
+    sidecar.istio.io/inject: "false"
+spec:
+  containers:
+  - name: c1
+    image: container-registry.oracle.com/os/oraclelinux:8
+    command: ['sh', '-c', 'echo "The app is running!" && tail -f /dev/null']
+    volumeMounts:
+    - name: pvc-old
+      mountPath: /prom-old
+    - name: pvc-new
+      mountPath: /prom-new
+  volumes:    
+  - name: pvc-old
+    persistentVolumeClaim:
+      claimName: prometheus-prometheus-operator-kube-p-prometheus-db-prometheus-prometheus-operator-kube-p-prometheus-0
+  - name: pvc-new
+    persistentVolumeClaim:
+      claimName: prometheus-kube-prometheus-stack-prometheus-db-prometheus-kube-prometheus-stack-prometheus-0 
+ EOF
+ 
+```
+
+Create the pod
+```text
+kubectl apply -f pod.yaml
+
+```
+
+Connect to the pod and copy the data
+```text
+
+kubectl exec -it -n  verrazzano-monitoring  shared-pvc  
+
+#remove Prometheus data from new pv
+rm -fr prom-new/*
+
+# create archiver of data from old pv
+tar -cvf prom.tar -C prom-old/ .
+
+# unpack data to new pv
+tar -xvf prom.tar -C prom-new/ 
+
+# delete the pod
+kubectl delete -f pod.yaml 
+
+# scale Prometheus up 
+kubectl scale sts -n  verrazzano-monitoring prometheus-kube-prometheus-stack-prometheus  --replicas=1
+```
+
+## Fix accesss to the Prometheus server
+In the section, you need to create the service used by auth-proxy to access Prometheus. They
+name of that service is hard coded in the auth-proxy, so it is required.
+
+Create the YAML file that specifies the service:
+```text
+cat > vz-prom-service.yaml <<EOF
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    meta.helm.sh/release-name: kube-prometheus-stack
+    meta.helm.sh/release-namespace: verrazzano-monitoring
+  labels:
+    app: kube-prometheus-stack-prometheus
+    app.kubernetes.io/instance: kube-prometheus-stack
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: kube-prometheus-stack
+    app.kubernetes.io/version: 45.25.0
+    chart: kube-prometheus-stack-45.25.0
+    heritage: Helm
+    release: kube-prometheus-stack
+    self-monitor: "true"
+    verrazzano-component: prometheus-operator
+  name: prometheus-operator-kube-p-prometheus
+  namespace: verrazzano-monitoring
+spec:
+  internalTrafficPolicy: Cluster
+  ipFamilies:
+  - IPv4
+  ipFamilyPolicy: SingleStack
+  ports:
+  - name: http-web
+    port: 9090
+    protocol: TCP
+    targetPort: 9090
+  selector:
+    app.kubernetes.io/name: prometheus
+    prometheus: kube-prometheus-stack-prometheus
+  sessionAffinity: None
+  type: ClusterIP
+  EOF
+```
+
+Create the service:
+```text
+kubectl apply -f vz-prom-service.yaml
+```
+
+Update the AuthorizationPolicy.  This is a one line change done using kubectl edit.
+Simply remove the existing principal for the verrazzano-monitoring namespace and
+replace it with the new one as shown below:
+
+```text
+kubectl edit authorizationpolicy -n verrazzano-monitoring   vmi-system-prometheus-authzpol
+...
+  - from:
+    - source:
+        namespaces:
+        - verrazzano-monitoring
+        principals:
+        - cluster.local/ns/verrazzano-monitoring/sa/kube-prometheus-stack-operator
 ```

--- a/doc/experimental/kube-prometheus-stack.md
+++ b/doc/experimental/kube-prometheus-stack.md
@@ -52,15 +52,6 @@ kubectl patch pv $PV_NAME -p '{"spec":{"persistentVolumeReclaimPolicy":"Retain"}
 uninstall -n verrazzano-monitoring prometheus-operator  
 ```
 
-Change reclaim policy to **Retain**.
-```text
-# get the pv-name (VOLUME NAME)
-PV_NAME=$(kubectl --kubeconfig ~/paul-kubeconfig.yaml get pvc -n verrazzano-monitoring -o jsonpath='{.items[0].spec.volumeName}')
- 
-# patch the PV 
-kubectl patch pv $PV_NAME -p '{"spec":{"persistentVolumeReclaimPolicy":"Retain"}}'
-```
-
 Update the existing installation:
 ```text
 ocne application update --release kube-state-metrics --namespace verrazzano-monitoring --version 2.8.2 --reset-values --values overrides.yaml

--- a/doc/experimental/kube-prometheus-stack.md
+++ b/doc/experimental/kube-prometheus-stack.md
@@ -36,6 +36,30 @@ sed -i '/prometheusDefaultBaseImageRegistry:/d' overrides.yaml
 sed -i '/image:/,+3d' overrides.yaml
 sed -i '/thanosImage:/,+3d' overrides.yaml
 ```
+## Change the Prometheus PV Reclaim Policy
+
+Change reclaim policy to **Retain**.  
+```text
+# get the pv-name (VOLUME NAME)
+PV_NAME=$(kubectl --kubeconfig ~/paul-kubeconfig.yaml get pvc -n verrazzano-monitoring -o jsonpath='{.items[0].spec.volumeName}')
+ 
+# patch the PV 
+kubectl patch pv $PV_NAME -p '{"spec":{"persistentVolumeReclaimPolicy":"Retain"}}'
+```
+
+## Uninstall Verrazzano kube-prometheus-stack (named prometheus-operator)
+```text
+uninstall -n verrazzano-monitoring prometheus-operator  
+```
+
+Change reclaim policy to **Retain**.
+```text
+# get the pv-name (VOLUME NAME)
+PV_NAME=$(kubectl --kubeconfig ~/paul-kubeconfig.yaml get pvc -n verrazzano-monitoring -o jsonpath='{.items[0].spec.volumeName}')
+ 
+# patch the PV 
+kubectl patch pv $PV_NAME -p '{"spec":{"persistentVolumeReclaimPolicy":"Retain"}}'
+```
 
 Update the existing installation:
 ```text

--- a/doc/experimental/kube-prometheus-stack.md
+++ b/doc/experimental/kube-prometheus-stack.md
@@ -61,7 +61,7 @@ PV_NAME=$(kubectl get pvc -n verrazzano-monitoring prometheus-prometheus-operato
 kubectl patch pv $PV_NAME -p '{"spec":{"persistentVolumeReclaimPolicy":"Retain"}}'
 ```
 
-## Uninstall Verrazzano kube-prometheus-stack (named prometheus-operator)
+## Uninstall Verrazzano prometheus-operator (actually kube-prometheus-stack)
 ```text
 helm delete -n verrazzano-monitoring prometheus-operator  
 ```

--- a/doc/experimental/kube-prometheus-stack.md
+++ b/doc/experimental/kube-prometheus-stack.md
@@ -1,0 +1,43 @@
+# Migrate to kube-prometheus-stack
+
+### Version: v0.0.1-draft
+
+Verrazzano installs the kube-prometheus-stack using a Helm chart named prometheus-operator.  As a result,
+the Helm release is named prometheus-operator and all resources that use {RELEASE-NAME} in the Helm
+manifests will have the name prometheus-operator. Consequently, you cannot directly upgrade to the 
+version of kube-prometheus-stack that exists in the catalog.  T
+
+In addition, the image section of the overrides file must be modified to use the correct images required
+by Oracle Cloud Native Environment.
+
+The purpose of this document is to migrate the Verrazzana kube-prometheus-stack (named prometheus-operator), 
+to the catalog kube-prometheus-stack so that future upgrades can be done using the catalog.  
+
+The steps are summarized below:
+1. export the Helm user provided overrides to an overrides file
+2. modify the image section of the overrides file
+3. change promethues PV reclaim policy to detain
+4. detach the prometheus PV
+5. uninstall the prometheus-operator chart (which is really the kube-prometheus-stack)
+6. install kube-state-metrics from the catalog using the override file from step 2 with PVC/PV overrides to use new PV
+
+## Modify the overrides
+
+Export the user supplied overrides of the current release to a file and remove the image overrides:
+```text
+helm get values -n verrazzano-monitoring prometheus-operator > overrides.yaml
+sed -i '1d' overrides.yaml
+sed -i '/image: ghcr.io/d' overrides.yaml
+sed -i '/alertmanagerDefaultBaseImage:/d' overrides.yaml
+sed -i '/alertmanagerDefaultBaseImageRegistry:/d' overrides.yaml
+sed -i '/prometheusDefaultBaseImage:/d' overrides.yaml
+sed -i '/prometheusDefaultBaseImageRegistry:/d' overrides.yaml
+
+sed -i '/image:/,+3d' overrides.yaml
+sed -i '/thanosImage:/,+3d' overrides.yaml
+```
+
+Update the existing installation:
+```text
+ocne application update --release kube-state-metrics --namespace verrazzano-monitoring --version 2.8.2 --reset-values --values overrides.yaml
+```

--- a/doc/experimental/phase1.md
+++ b/doc/experimental/phase1.md
@@ -8,6 +8,12 @@ The instructions must be performed in the sequence outlined in this document.
 
 Follow these [instructions](https://docs.oracle.com/en/operating-systems/olcne/2.0/cli/ocne_install_task.html#ocne_install) to install the 2.0 CLI on the cluster.
 
+## Install Oracle Cloud Native Environment 2.0 Catalog and UI
+
+```text
+ocne cluster start --provider none --kubeconfig $KUBECONFIG --auto-start-ui false
+kubectl -n ocne-system rollout status deployment ocne-catalog
+```
 ## Perform a Custer Dump
 
 Perform a cluster dump to take snapshot of the cluster state before the migration begins.
@@ -16,14 +22,7 @@ If you want to redact sensitive information, such as host names, or omit configm
 respective flags:
 
 ```text
-ocne cluster dump --skip-redaction --include-configmaps -d /tmp/dump/before-phase1
-```
-
-## Install Oracle Cloud Native Environment 2.0 Catalog and UI
-
-```text
-ocne cluster start --provider none --kubeconfig $KUBECONFIG --auto-start-ui false
-kubectl -n ocne-system rollout status deployment ocne-catalog
+ocne cluster dump --kubeconfig $KUBECONFIG --skip-redaction --include-configmaps -d /tmp/dump/before-phase1
 ```
 
 ## Turn off the Verrazzano controllers
@@ -316,5 +315,5 @@ If you want to redact sensitive information, such as host names, or omit configm
 respective flags:
 
 ```text
-ocne cluster dump --skip-redaction --include-configmaps -d /tmp/dump/after-phase1
+ocne cluster dump --kubeconfig $KUBECONFIG --skip-redaction --include-configmaps -d /tmp/dump/after-phase1
 ```

--- a/doc/experimental/phase1.md
+++ b/doc/experimental/phase1.md
@@ -8,6 +8,17 @@ The instructions must be performed in the sequence outlined in this document.
 
 Follow these [instructions](https://docs.oracle.com/en/operating-systems/olcne/2.0/cli/ocne_install_task.html#ocne_install) to install the 2.0 CLI on the cluster.
 
+## Perform a Custer Dump
+
+Perform a cluster dump to take snapshot of the cluster state before the migration begins.
+This may take several minutes, it varies depending on the size of your cluster and number of cluster objects.
+If you want to redact sensitive information, such as host names, or omit configmaps then, remove the
+respective flags:
+
+```text
+ocne cluster dump --skip-redaction --include-configmaps -d /tmp/dump/before-phase1
+```
+
 ## Install Oracle Cloud Native Environment 2.0 Catalog and UI
 
 ```text
@@ -99,3 +110,14 @@ ocne application update --release kube-state-metrics --namespace verrazzano-moni
 
 ### Remove OAM resources
 TDB
+
+## Perform another Custer Dump
+
+Perform a cluster dump to take snapshot of the cluster state after phase-1 is done.
+This may take several minutes, it varies depending on the size of your cluster and number of cluster objects.
+If you want to redact sensitive information, such as host names, or omit configmaps then, remove the
+respective flags:
+
+```text
+ocne cluster dump --skip-redaction --include-configmaps -d /tmp/dump/after-phase1
+```

--- a/doc/experimental/phase1.md
+++ b/doc/experimental/phase1.md
@@ -85,9 +85,13 @@ The installed version of Grafana needs to be transformed to be manageable by Hel
 
 **TBD**
 
-## Modify kube-prometheus-stack (named as prometheus-operator) to be managed by Helm
+## Modify kube-prometheus-stack to be managed by Helm
 
-**TBD**  We may need to uninstall prometheus-operator and then install kube-prometheus-stack.
+See [Migrate kube-prometheus-stack](./kube-prometheus-stack.md)
+
+## Modify prometheus-node-exporter Helm Overrides
+
+**TBD**
 
 ## Modify kube-state-metrics to be managed by Helm
 


### PR DESCRIPTION
This document describes how to migrate from Verrazano prometheus-operator (which is really the kube-prometheus-stack) to the catalog kube-prometheus-stack.