### PR TITLE
Added OCNE_DEFAULTS environment variable to change the path of the default configuration

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -114,7 +114,15 @@ func GetDefaultConfig() (*types.Config, error) {
 	}
 	defaultConfig.SshPublicKeyPath = sshKeyPath
 
-	configFileDefaults, err := ParseConfigFile(filepath.Join(homedir, constants.UserConfigDefaults))
+	// Load in the defaults.  Prefer the path set by OCNE_DEFAULTS_FILE.
+	// If that is not set, use the default path.
+	defaultPath := filepath.Join(homedir, constants.UserConfigDefaults)
+	defaultPathOvr := os.Getenv(constants.UserConfigDefaultsEnvironmentVariable)
+	if defaultPathOvr != "" {
+		defaultPath = defaultPathOvr
+	}
+
+	configFileDefaults, err := ParseConfigFile(defaultPath)
 	if os.IsNotExist(err) {
 		return &defaultConfig, nil
 	} else if err != nil {

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -4,12 +4,13 @@
 package constants
 
 const (
-	DarwinLibvirtSocketPath = ".cache/libvirt/libvirt-sock"
-	UserConfigDir           = ".ocne"
-	UserConfigDefaults      = ".ocne/defaults.yaml"
-	UserImageCacheDir       = "images"
-	UserContainerConfigDir  = "config"
-	UserIPData              = "ips.yaml"
+	DarwinLibvirtSocketPath               = ".cache/libvirt/libvirt-sock"
+	UserConfigDir                         = ".ocne"
+	UserConfigDefaults                    = ".ocne/defaults.yaml"
+	UserConfigDefaultsEnvironmentVariable = "OCNE_DEFAULTS"
+	UserImageCacheDir                     = "images"
+	UserContainerConfigDir                = "config"
+	UserIPData                            = "ips.yaml"
 
 	BootVolumeContainerImage = "docker://container-registry.oracle.com/olcne/ock"
 


### PR DESCRIPTION
Allows users to override the location of the default configuration file.

Example
```
#
#   Set an alternate default file that has no proxy configuration
#
$ cat ~/.ocne/defaults-noproxy.yaml
extraIgnitionInline: |
  variant: fcos
  version: 1.5.0
  passwd:
    users:
      - name: dkrasins
        groups:
          - wheel
        ssh_authorized_keys:
          - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDAfNhm5APW2kctfj+O8IRInlFivqoQMvMQ9CCNMq5IavW+CKTJUQ74pn8YkAmagM44zXPpwDoFiE+Wmk7fncigMu/x6T1qDLlz0P5XCXU1LQD35MOjtzQPyIRngaDbJ3f4H34w/WzyFVAH4wOPCiTa3eHRWU9ZLBK5MooDp1paC91NDUU4iLmRIVgBPbI7XPziRRvKQpUo9MPmXSjvOY/bvwAFZZB0uePR6RQBofVABisUJEE1Coo3EZmreekoreftUH6Xm+JI016sXMkQydfHsHztEL2C4zYUOfZmya0ThWkYSelUyZmOJU+3R3CQ56F04YGdqIQPA7WLGH0Q/IXzIGE2cNVxsceFraVLCuRTnzHoh4Hg6BrfVWWAm2siGNZP/6hldA3TIpyHMDKE6wJ3T/iONP1eI6ojgz6rnRUQzgxzjEGCpSuoFWaPlweYKksldIuflKijC3jGAbmqFNe/6UMVmGk7nRu/IE2K7XO/bgSTOCxf+KPUBCfATGiK3y0= root@dkrasins-dev-ol9

$ OCNE_DEFAULTS=$(realpath ~/.ocne/defaults-noproxy.yaml) ./out/linux_amd64/ocne cluster start -C otherdefaults --auto-start-ui=false
INFO[2024-10-18T15:48:08Z] Creating new Kubernetes cluster with version 1.30 named otherdefaults 
INFO[2024-10-18T15:48:53Z] Waiting for the Kubernetes cluster to be ready: ok 
...
Run the following command to create an authentication token to access the UI:
    kubectl create token ui -n ocne-system 
[opc@dkrasins-dev-ol9 ocne]$ ocne cluster show -C otherdefaults -f 'config.proxy'
httpsProxy: ""
httpProxy: ""
noProxy: ""

$ ocne cluster delete -C otherdefaults
INFO[2024-10-18T15:49:20Z] Deleting volume otherdefaults-control-plane-1-init.ign 
INFO[2024-10-18T15:49:20Z] Deleting volume otherdefaults-control-plane-1.qcow2 
INFO[2024-10-18T15:49:20Z] Deleting file /home/opc/.kube/kubeconfig.otherdefaults.local 
INFO[2024-10-18T15:49:20Z] Deleting file /home/opc/.kube/kubeconfig.otherdefaults.vm 

#
#  Set a default configuration file that has a proxy set
#
$ cat ~/.ocne/defaults-fakeproxy.yaml 
proxy:
  httpsProxy: "https://fakeproxy.com:80"
  httpProxy: "https://fakeproxy.com:80"
  noProxy: "0.0.0.0/0"

$ OCNE_DEFAULTS=$(realpath ~/.ocne/defaults-fakeproxy.yaml) ./out/linux_amd64/ocne cluster start -C otherdefaults --auto-start-ui=false
INFO[2024-10-18T15:49:32Z] Creating new Kubernetes cluster with version 1.30 named otherdefaults 
INFO[2024-10-18T15:50:20Z] Waiting for the Kubernetes cluster to be ready: ok 
...
Run the following command to create an authentication token to access the UI:
    kubectl create token ui -n ocne-system 


$ ocne cluster show -C otherdefaults -f 'config.proxy'
httpsProxy: https://fakeproxy.com:80
httpProxy: https://fakeproxy.com:80
noProxy: 0.0.0.0/0
```