### PR TITLE
Honor the registry override in defaults.yaml for the "none" provider

### DIFF
--- a/cmd/cluster/delete/delete.go
+++ b/cmd/cluster/delete/delete.go
@@ -4,13 +4,14 @@
 package delete
 
 import (
-	"github.com/spf13/cobra"
 	"github.com/oracle-cne/ocne/cmd/constants"
 	"github.com/oracle-cne/ocne/pkg/cluster/cache"
 	"github.com/oracle-cne/ocne/pkg/cmdutil"
 	delete2 "github.com/oracle-cne/ocne/pkg/commands/cluster/delete"
 	config2 "github.com/oracle-cne/ocne/pkg/config"
 	"github.com/oracle-cne/ocne/pkg/config/types"
+	pkgconst "github.com/oracle-cne/ocne/pkg/constants"
+	"github.com/spf13/cobra"
 )
 
 const (
@@ -99,7 +100,7 @@ func RunCmd(cmd *cobra.Command) error {
 		cc.Name = "ocne"
 	}
 	if cc.Provider == "" {
-		cc.Provider = "libvirt"
+		cc.Provider = pkgconst.ProviderTypeLibVirt
 	}
 
 	err = delete2.Delete(c, cc)

--- a/cmd/cluster/delete/delete.go
+++ b/cmd/cluster/delete/delete.go
@@ -100,7 +100,7 @@ func RunCmd(cmd *cobra.Command) error {
 		cc.Name = "ocne"
 	}
 	if cc.Provider == "" {
-		cc.Provider = pkgconst.ProviderTypeLibVirt
+		cc.Provider = pkgconst.ProviderTypeLibvirt
 	}
 
 	err = delete2.Delete(c, cc)

--- a/cmd/cluster/start/start.go
+++ b/cmd/cluster/start/start.go
@@ -86,7 +86,7 @@ func RunCmd(cmd *cobra.Command) error {
 		cc.Name = "ocne"
 	}
 	if cc.Provider == "" {
-		cc.Provider = "libvirt"
+		cc.Provider = pkgconst.ProviderTypeLibVirt
 	}
 	if cc.ControlPlaneNodes == 0 {
 		cc.ControlPlaneNodes = 1
@@ -111,7 +111,7 @@ func RunCmd(cmd *cobra.Command) error {
 
 	// if the provider is libvirt, update fields in the config otherwise the changes to the clusterConfig fields
 	// will be overwritten
-	if cc.Provider == "libvirt" {
+	if cc.Provider == pkgconst.ProviderTypeLibVirt {
 		c.BootVolumeContainerImage = cc.BootVolumeContainerImage
 		c.KubeVersion = cc.KubeVersion
 		c.OsTag = cc.OsTag

--- a/cmd/cluster/start/start.go
+++ b/cmd/cluster/start/start.go
@@ -86,7 +86,7 @@ func RunCmd(cmd *cobra.Command) error {
 		cc.Name = "ocne"
 	}
 	if cc.Provider == "" {
-		cc.Provider = pkgconst.ProviderTypeLibVirt
+		cc.Provider = pkgconst.ProviderTypeLibvirt
 	}
 	if cc.ControlPlaneNodes == 0 {
 		cc.ControlPlaneNodes = 1
@@ -111,7 +111,7 @@ func RunCmd(cmd *cobra.Command) error {
 
 	// if the provider is libvirt, update fields in the config otherwise the changes to the clusterConfig fields
 	// will be overwritten
-	if cc.Provider == pkgconst.ProviderTypeLibVirt {
+	if cc.Provider == pkgconst.ProviderTypeLibvirt {
 		c.BootVolumeContainerImage = cc.BootVolumeContainerImage
 		c.KubeVersion = cc.KubeVersion
 		c.OsTag = cc.OsTag

--- a/cmd/cluster/template/template.go
+++ b/cmd/cluster/template/template.go
@@ -47,7 +47,7 @@ func NewCmd() *cobra.Command {
 	cmdutil.SilenceUsage(cmd)
 
 	cmd.Flags().StringVarP(&kubeConfig, constants.FlagKubeconfig, constants.FlagKubeconfigShort, "", constants.FlagKubeconfigHelp)
-	cmd.Flags().StringVarP(&opts.ClusterConfig.Provider, constants.FlagProviderName, constants.FlagProviderNameShort, "oci", constants.FlagProviderNameHelp)
+	cmd.Flags().StringVarP(&opts.ClusterConfig.Provider, constants.FlagProviderName, constants.FlagProviderNameShort, pkgconst.ProviderTypeOCI, constants.FlagProviderNameHelp)
 	cmd.Flags().StringVarP(&clusterConfigPath, constants.FlagConfig, constants.FlagConfigShort, "", constants.FlagConfigHelp)
 	return cmd
 }

--- a/pkg/cluster/driver/none/none.go
+++ b/pkg/cluster/driver/none/none.go
@@ -4,8 +4,10 @@ package none
 
 import (
 	"fmt"
+
 	"github.com/oracle-cne/ocne/pkg/cluster/driver"
 	"github.com/oracle-cne/ocne/pkg/config/types"
+	"github.com/oracle-cne/ocne/pkg/constants"
 )
 
 const (
@@ -17,7 +19,7 @@ type NoneDriver struct {
 }
 
 func CreateDriver(config *types.Config, clusterConfig *types.ClusterConfig) (driver.ClusterDriver, error) {
-	if clusterConfig.Provider == "none" && config.KubeConfig == "" {
+	if clusterConfig.Provider == constants.ProviderTypeNone && config.KubeConfig == "" {
 		return nil, fmt.Errorf("When the none provider is used, an existing kubeconfig file must be specified")
 	}
 	ret := &NoneDriver{

--- a/pkg/cluster/template/templates.go
+++ b/pkg/cluster/template/templates.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 
 	"github.com/oracle-cne/ocne/pkg/config/types"
+	"github.com/oracle-cne/ocne/pkg/constants"
 )
 
 //go:embed all:templates
@@ -21,7 +22,7 @@ func GetTemplate(config *types.Config, clusterConfig *types.ClusterConfig) (stri
 	var tmpl string
 	var err error
 	switch clusterConfig.Provider {
-	case "oci":
+	case constants.ProviderTypeOCI:
 		tmpl, err = GetOciTemplate(config, clusterConfig)
 	default:
 		return "", fmt.Errorf("templates not implemented for provider %s", clusterConfig.Provider)

--- a/pkg/commands/application/install/applications.go
+++ b/pkg/commands/application/install/applications.go
@@ -5,18 +5,19 @@ package install
 
 import (
 	"fmt"
+
 	"github.com/oracle-cne/ocne/pkg/commands/application"
 	"github.com/oracle-cne/ocne/pkg/commands/catalog/search"
 	"github.com/oracle-cne/ocne/pkg/constants"
 	"github.com/oracle-cne/ocne/pkg/k8s/client"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/oracle-cne/ocne/pkg/catalog"
 	"github.com/oracle-cne/ocne/pkg/config/types"
 	"github.com/oracle-cne/ocne/pkg/helm"
 	"github.com/oracle-cne/ocne/pkg/k8s"
 	"github.com/oracle-cne/ocne/pkg/util"
 	"github.com/oracle-cne/ocne/pkg/util/logutils"
+	log "github.com/sirupsen/logrus"
 	"sigs.k8s.io/yaml"
 )
 

--- a/pkg/commands/cluster/start/start.go
+++ b/pkg/commands/cluster/start/start.go
@@ -5,28 +5,27 @@ package start
 
 import (
 	"fmt"
-	"github.com/oracle-cne/ocne/pkg/cluster"
 	"runtime"
 	"strings"
 
-	"helm.sh/helm/v3/pkg/release"
+	"github.com/oracle-cne/ocne/pkg/catalog"
+	"github.com/oracle-cne/ocne/pkg/cluster"
+	"github.com/oracle-cne/ocne/pkg/cluster/cache"
+	"github.com/oracle-cne/ocne/pkg/cluster/driver"
 	"github.com/oracle-cne/ocne/pkg/commands/application/install"
 	"github.com/oracle-cne/ocne/pkg/commands/catalog/add"
 	"github.com/oracle-cne/ocne/pkg/commands/catalog/ls"
-	"github.com/oracle-cne/ocne/pkg/helm"
-	"github.com/oracle-cne/ocne/pkg/k8s/client"
-
-	log "github.com/sirupsen/logrus"
-	k8stypes "k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/kubernetes"
-	"github.com/oracle-cne/ocne/pkg/catalog"
-	"github.com/oracle-cne/ocne/pkg/cluster/cache"
-	"github.com/oracle-cne/ocne/pkg/cluster/driver"
 	"github.com/oracle-cne/ocne/pkg/config/types"
 	"github.com/oracle-cne/ocne/pkg/constants"
+	"github.com/oracle-cne/ocne/pkg/helm"
 	"github.com/oracle-cne/ocne/pkg/k8s"
+	"github.com/oracle-cne/ocne/pkg/k8s/client"
 	"github.com/oracle-cne/ocne/pkg/unix"
 	"github.com/oracle-cne/ocne/pkg/util/logutils"
+	log "github.com/sirupsen/logrus"
+	"helm.sh/helm/v3/pkg/release"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
 )
 
 const (
@@ -49,7 +48,7 @@ func Start(config *types.Config, clusterConfig *types.ClusterConfig) (string, er
 	if err != nil {
 		return "", err
 	}
-	if clusterConfig.Provider != "none" {
+	if clusterConfig.Provider != constants.ProviderTypeNone {
 		cachedClusterConfig := clusterCache.Get(clusterConfig.Name)
 		if cachedClusterConfig != nil {
 			if cachedClusterConfig.ClusterConfig.Provider != clusterConfig.Provider {
@@ -100,7 +99,7 @@ func Start(config *types.Config, clusterConfig *types.ClusterConfig) (string, er
 	// Install charts that are baked in to this application and from
 	// the Oracle catalog.
 	var applications []install.ApplicationDescription
-	if clusterConfig.Provider != "none" {
+	if clusterConfig.Provider != constants.ProviderTypeNone {
 		switch clusterConfig.CNI {
 		case "", constants.CNIFlannel:
 			log.Debugf("Flannel will be installed as the CNI")

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -68,7 +68,7 @@ const (
 	K8sLabelControlPlane = "node-role.kubernetes.io/control-plane"
 
 	// Provider Types
-	ProviderTypeLibVirt = "libvirt"
+	ProviderTypeLibvirt = "libvirt"
 	ProviderTypeOCI     = "oci"
 	ProviderTypeNone    = "none"
 )

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -33,8 +33,6 @@ const (
 	EphemeralClusterName         = "ocne-ephemeral"
 	EphemeralClusterPreserve     = true
 
-	NetworkName = "default"
-
 	// Kubernetes defaults`
 	KubeAPIServerBindPort    = uint16(6443)
 	KubeAPIServerBindPortAlt = uint16(6444)
@@ -68,6 +66,11 @@ const (
 
 	// Kubernetes Labels
 	K8sLabelControlPlane = "node-role.kubernetes.io/control-plane"
+
+	// Provider Types
+	ProviderTypeLibVirt = "libvirt"
+	ProviderTypeOCI     = "oci"
+	ProviderTypeNone    = "none"
 )
 
 var OciArmCompatibleShapes = [...]string{OciVmStandardA1Flex, OciBmStandardA1160}


### PR DESCRIPTION
When starting a cluster with the "none" provider, override the registry value for the app-catalog and ui if it is set in defaults.yaml (and different than the setting in values.yaml)

Created constants for the provider types.