### PR TITLE
Fix ServiceMonitors and PodMonitors to bind to new Prometheus Operator

### DIFF
--- a/doc/experimental/phase1/kube-prometheus-stack.md
+++ b/doc/experimental/phase1/kube-prometheus-stack.md
@@ -244,10 +244,10 @@ kubectl delete -f pod.yaml --force
 ```
 
 ## Patch ServiceMonitors and PodMonitors
-Both the ServiceMonitors and PodMonitors need to be patched so that they can be processed by the Prometheus operator
+Both the ServiceMonitors and PodMonitors need to be patched so that they can be processed by the Prometheus operator.
 
-### Patch the system resources
-Following is the list of system resources that need to be patched: 
+### Patch the system ServiceMonitors and PodMonitors
+Patch the following objects: 
 ```text
 kubectl patch servicemonitor -n verrazzano-monitoring authproxy --type='merge'  -p '{"metadata":{"labels":{"release":"kube-prometheus-stack"}}}'
 kubectl patch servicemonitor -n verrazzano-monitoring fluentd --type='merge'  -p '{"metadata":{"labels":{"release":"kube-prometheus-stack"}}}'
@@ -270,8 +270,9 @@ kubectl patch servicemonitor -n verrazzano-monitoring prometheus-node-exporter -
 kubectl patch podmonitor -n verrazzano-monitoring envoy-stats --type='merge'  -p '{"metadata":{"labels":{"release":"kube-prometheus-stack"}}}'
 kubectl patch podmonitor -n verrazzano-monitoring  nginx-ingress-controller --type='merge'  -p '{"metadata":{"labels":{"release":"kube-prometheus-stack"}}}'
 ```
-### Patch the system resources
-You also need to patch your application resources. For example
+
+### Patch the application ServiceMonitors and PodMonitors
+You also need to patch your application objects. For example:
 ```text
 kubectl patch servicemonitor -n todo-list todo-appconf-todo-list-todo-domain --type='merge'  -p '{"metadata":{"labels":{"release":"kube-prometheus-stack"}}}'
 kubectl patch servicemonitor -n todo-list todo-appconf-todo-list-todo-mysql-deployment --type='merge'  -p '{"metadata":{"labels":{"release":"kube-prometheus-stack"}}}'

--- a/doc/experimental/phase1/kube-prometheus-stack.md
+++ b/doc/experimental/phase1/kube-prometheus-stack.md
@@ -1,6 +1,6 @@
 # Migrate to kube-prometheus-stack
 
-### Version: v0.0.5-draft
+### Version: v0.0.6-draft
 
 The purpose of this document is describe how to migrate the Verrazzano kube-prometheus-stack (named prometheus-operator)
 to the catalog kube-prometheus-stack. Once this is done, upgrades to kube-prometheus-stack can be done using the catalog. 
@@ -143,8 +143,6 @@ kubectl edit AuthorizationPolicy -n verrazzano-system       vmi-system-es-master
 
 kubectl edit AuthorizationPolicy -n verrazzano-system       vmi-system-grafana-authzpol  
 
-kubectl edit AuthorizationPolicy -n verrazzano-system       vmi-system-kiali-authzpol  
-
 kubectl edit AuthorizationPolicy -n verrazzano-system       vmi-system-osd-authzpol  
 
 Delete the obsolete AuthorizationPolicy
@@ -159,6 +157,8 @@ Run this command to find the policies, then edit each and change the principal a
 ```text
 kubectl get AuthorizationPolicy -A -o yaml | grep prometheus-operator-kube-p-prometheus -B20
 ```
+For each policy, replace old `cluster.local/ns/verrazzano-monitoring/sa/prometheus-operator-kube-p-prometheus`  
+with new `cluster.local/ns/verrazzano-monitoring/sa/kube-prometheus-stack-prometheus`
 
 
 ## Migrate metrics data from old PV to new PV
@@ -241,6 +241,40 @@ cp -R /prom-old/. prom-new/
 Delete the pod
 ```text
 kubectl delete -f pod.yaml --force
+```
+
+## Patch ServiceMonitors and PodMonitors
+Both the ServiceMonitors and PodMonitors need to be patched so that they can be processed by the Prometheus operator
+
+### Patch the system resources
+Following is the list of system resources that need to be patched: 
+```text
+kubectl patch servicemonitor -n verrazzano-monitoring authproxy --type='merge'  -p '{"metadata":{"labels":{"release":"kube-prometheus-stack"}}}'
+kubectl patch servicemonitor -n verrazzano-monitoring fluentd --type='merge'  -p '{"metadata":{"labels":{"release":"kube-prometheus-stack"}}}'
+kubectl patch servicemonitor -n verrazzano-monitoring jaeger --type='merge'  -p '{"metadata":{"labels":{"release":"kube-prometheus-stack"}}}'
+kubectl patch servicemonitor -n verrazzano-monitoring jaeger-operator --type='merge'  -p '{"metadata":{"labels":{"release":"kube-prometheus-stack"}}}'
+kubectl patch servicemonitor -n verrazzano-monitoring kube-prometheus-stack-apiserver --type='merge'  -p '{"metadata":{"labels":{"release":"kube-prometheus-stack"}}}'
+kubectl patch servicemonitor -n verrazzano-monitoring kube-prometheus-stack-coredns --type='merge'  -p '{"metadata":{"labels":{"release":"kube-prometheus-stack"}}}'
+kubectl patch servicemonitor -n verrazzano-monitoring kube-prometheus-stack-kube-controller-manager --type='merge'  -p '{"metadata":{"labels":{"release":"kube-prometheus-stack"}}}'
+kubectl patch servicemonitor -n verrazzano-monitoring kube-prometheus-stack-kube-etcd --type='merge'  -p '{"metadata":{"labels":{"release":"kube-prometheus-stack"}}}'
+kubectl patch servicemonitor -n verrazzano-monitoring kube-prometheus-stack-kube-proxy --type='merge'  -p '{"metadata":{"labels":{"release":"kube-prometheus-stack"}}}'
+kubectl patch servicemonitor -n verrazzano-monitoring kube-prometheus-stack-kube-scheduler --type='merge'  -p '{"metadata":{"labels":{"release":"kube-prometheus-stack"}}}'
+kubectl patch servicemonitor -n verrazzano-monitoring kube-prometheus-stack-kubelet --type='merge'  -p '{"metadata":{"labels":{"release":"kube-prometheus-stack"}}}'
+kubectl patch servicemonitor -n verrazzano-monitoring kube-prometheus-stack-operator --type='merge'  -p '{"metadata":{"labels":{"release":"kube-prometheus-stack"}}}'
+kubectl patch servicemonitor -n verrazzano-monitoring kube-prometheus-stack-prometheus --type='merge'  -p '{"metadata":{"labels":{"release":"kube-prometheus-stack"}}}'
+kubectl patch servicemonitor -n verrazzano-monitoring kube-state-metrics --type='merge'  -p '{"metadata":{"labels":{"release":"kube-prometheus-stack"}}}'
+kubectl patch servicemonitor -n verrazzano-monitoring opensearch --type='merge'  -p '{"metadata":{"labels":{"release":"kube-prometheus-stack"}}}'
+kubectl patch servicemonitor -n verrazzano-monitoring pilot --type='merge'  -p '{"metadata":{"labels":{"release":"kube-prometheus-stack"}}}'
+kubectl patch servicemonitor -n verrazzano-monitoring prometheus-node-exporter --type='merge'  -p '{"metadata":{"labels":{"release":"kube-prometheus-stack"}}}'
+
+kubectl patch podmonitor -n verrazzano-monitoring envoy-stats --type='merge'  -p '{"metadata":{"labels":{"release":"kube-prometheus-stack"}}}'
+kubectl patch podmonitor -n verrazzano-monitoring  nginx-ingress-controller --type='merge'  -p '{"metadata":{"labels":{"release":"kube-prometheus-stack"}}}'
+```
+### Patch the system resources
+You also need to patch your application resources. For example
+```text
+kubectl patch servicemonitor -n todo-list todo-appconf-todo-list-todo-domain --type='merge'  -p '{"metadata":{"labels":{"release":"kube-prometheus-stack"}}}'
+kubectl patch servicemonitor -n todo-list todo-appconf-todo-list-todo-mysql-deployment --type='merge'  -p '{"metadata":{"labels":{"release":"kube-prometheus-stack"}}}'
 ```
 
 ## Scale-out Prometheus


### PR DESCRIPTION
Fix ServiceMonitors and PodMonitors to bind to new Prometheus Operator.  This is done by changing the release label.  Without this fix, the operator will not process the monitor resources.
With this fix, all the scrape targets are working for both envoy metrics and app metrics.

Also remove edit to Kiali authorizationpolicy, which is not needed.