### PR TITLE
 131-yaml-parse-errors-are-not-attributed-to-the-bad-file 

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -12,6 +12,7 @@ import (
 	"github.com/oracle-cne/ocne/pkg/cluster/ignition"
 	"github.com/oracle-cne/ocne/pkg/config/types"
 	"github.com/oracle-cne/ocne/pkg/constants"
+	"fmt"
 )
 
 // ParseConfig takes a yaml-encoded string and parses it
@@ -33,7 +34,11 @@ func ParseConfigFile(configPath string) (*types.Config, error) {
 		return nil, err
 	}
 
-	return ParseConfig(string(configBytes))
+	conf, err := ParseConfig(string(configBytes))
+	if err != nil {
+		return nil, fmt.Errorf("error parsing config file %s: %s", configPath, err.Error())
+	}
+	return conf, nil
 }
 
 // GetDefaultConfig returns the global default config.  It starts
@@ -153,7 +158,7 @@ func ParseClusterConfigFile(configPath string) (*types.ClusterConfig, error) {
 	}
 	ret, err := ParseClusterConfig(string(configBytes))
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error parsing config file %s: %s", configPath, err.Error())
 	}
 
 	// If the directory is not set, then set it to the

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -36,7 +36,7 @@ func ParseConfigFile(configPath string) (*types.Config, error) {
 
 	conf, err := ParseConfig(string(configBytes))
 	if err != nil {
-		return nil, fmt.Errorf("error parsing config file %s: %s", configPath, err.Error())
+		return nil, fmt.Errorf("could not parse config file %s: %s", configPath, err.Error())
 	}
 	return conf, nil
 }
@@ -158,7 +158,7 @@ func ParseClusterConfigFile(configPath string) (*types.ClusterConfig, error) {
 	}
 	ret, err := ParseClusterConfig(string(configBytes))
 	if err != nil {
-		return nil, fmt.Errorf("error parsing config file %s: %s", configPath, err.Error())
+		return nil, fmt.Errorf("could not parse config file %s: %s", configPath, err.Error())
 	}
 
 	// If the directory is not set, then set it to the


### PR DESCRIPTION
I tested that the erroneous file is identified in the output in the case that 
1. the default file is invalid
2. the user passed in file is invalid
3. both are invalid

I also tested the case where both files are valid and made sure no error is observed.

