### PR TITLE
OCNE Info Command

### DIFF
--- a/cmd/info/info.go
+++ b/cmd/info/info.go
@@ -1,0 +1,45 @@
+// Copyright (c) 2024, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package info
+
+import (
+	"fmt"
+	"github.com/oracle-cne/ocne/pkg/cmdutil"
+	"github.com/spf13/cobra"
+)
+
+const (
+	CommandName = "info"
+	helpShort   = "Display information about OCNE "
+	helpLong    = `Display information about OCNE that may be difficult to find.`
+	helpExample = `
+ocne info
+`
+)
+
+func NewCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   CommandName,
+		Short: helpShort,
+		Long:  helpLong,
+		Args:  cobra.MatchAll(cobra.ExactArgs(0), cobra.OnlyValidArgs),
+	}
+
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		return RunCmd(cmd)
+	}
+	cmdutil.SilenceUsage(cmd)
+	cmd.Example = helpExample
+
+	return cmd
+}
+
+// RunCmd runs the "ocne info" command
+func RunCmd(cmd *cobra.Command) error {
+	fmt.Println("The OCNE_DEFAULTS environment variable sets the location of the default configuration file.")
+	fmt.Println("The KUBECONFIG environment variable sets the location of the kubeconfig file. This behaves the same way as the --kubeconfig option for most ocne commands.")
+	fmt.Println("The EDITOR environment variable sets the default document editor.")
+	return nil
+
+}

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -4,13 +4,14 @@
 package root
 
 import (
-	log "github.com/sirupsen/logrus"
-	"github.com/spf13/cobra"
 	"github.com/oracle-cne/ocne/cmd/application"
 	"github.com/oracle-cne/ocne/cmd/catalog"
 	"github.com/oracle-cne/ocne/cmd/cluster"
 	"github.com/oracle-cne/ocne/cmd/image"
+	"github.com/oracle-cne/ocne/cmd/info"
 	"github.com/oracle-cne/ocne/cmd/node"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
 )
 
 const (
@@ -51,6 +52,7 @@ func NewRootCmd() *cobra.Command {
 	cmd.AddCommand(cluster.NewCmd())
 	cmd.AddCommand(node.NewCmd())
 	cmd.AddCommand(image.NewCmd())
+	cmd.AddCommand(info.NewCmd())
 
 	cmd.PersistentFlags().StringVarP(&logLevel, flagLogLevel, flagLogLevelShort, "info", flagLogLevelHelp)
 


### PR DESCRIPTION
In this PR, I add the ocne info command in order to display output about OCNE environmental variables. 

```
./ocne info            
The OCNE_DEFAULTS environment variable sets the location of the default configuration file.
The KUBECONFIG environment variable sets the location of the kubeconfig file. This behaves the same way as the --kubeconfig option for most ocne commands.
The EDITOR environment variable sets the default document editor.
```