### PR TITLE
Allow arbitrary ignition provider configuration and extra kernel arguments

### DIFF
--- a/cmd/image/create/create.go
+++ b/cmd/image/create/create.go
@@ -37,6 +37,14 @@ const (
 	flagProviderType      = "type"
 	flagProviderTypeShort = "t"
 	flagProviderTypeHelp  = "The provider type, default is oci"
+
+	flagIgnitionProvider      = "ignition-provider"
+	flagIgnitionProviderShort = "i"
+	flagIgnitionProviderHelp  = "The kernel command line arguments to configure the ignition provider"
+
+	flagKargs      = "kernel-args"
+	flagKargsShort = "K"
+	flagKargsHelp  = "Additional kernel command line arguments to append to the end of the argument list"
 )
 
 func NewCmd() *cobra.Command {
@@ -56,6 +64,8 @@ func NewCmd() *cobra.Command {
 	cmd.Flags().StringVarP(&config.KubeConfig, constants.FlagKubeconfig, constants.FlagKubeconfigShort, "", constants.FlagKubeconfigHelp)
 	cmd.Flags().StringVarP(&createOptions.ProviderType, flagProviderType, flagProviderTypeShort, create.ProviderTypeOCI, flagProviderTypeHelp)
 	cmd.Flags().StringVarP(&createOptions.Architecture, flags.FlagArchitecture, flags.FlagArchitectureShort, "amd64", flagArchitectureHelp)
+	cmd.Flags().StringVarP(&createOptions.IgnitionProvider, flagIgnitionProvider, flagIgnitionProviderShort, "", flagIgnitionProviderHelp)
+	cmd.Flags().StringVarP(&createOptions.KernelArguments, flagKargs, flagKargsShort, "", flagKargsHelp)
 	cmd.Flags().StringVarP(&clusterConfig.KubeVersion, constants.FlagVersionName, constants.FlagVersionShort, "", constants.FlagKubernetesVersionHelp)
 
 	return cmd

--- a/pkg/commands/image/create/create.go
+++ b/pkg/commands/image/create/create.go
@@ -6,6 +6,7 @@ package create
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/oracle-cne/ocne/pkg/k8s/client"
 	"github.com/oracle-cne/ocne/pkg/k8s/kubectl"
@@ -26,19 +27,26 @@ const ProviderTypeOCI = "oci"
 const ProviderTypeOstree = "ostree"
 
 const (
-	podName         = "ocne-image-builder"
-	cmName          = "ocne-image-builder"
-	imageMountPath  = "/ocne-image-build"
-	remoteFilePath  = "/tmp/boot.qcow2"
-	localVMImage    = "boot.qcow2"
-	tempDir         = "create-images"
-	envProviderType = "IGNITION_PROVIDER_TYPE"
+	podName           = "ocne-image-builder"
+	cmName            = "ocne-image-builder"
+	imageMountPath    = "/ocne-image-build"
+	remoteFilePath    = "/tmp/boot.qcow2"
+	localVMImage      = "boot.qcow2"
+	tempDir           = "create-images"
+	envIgnitionStanza = "IGNITION_STANZA"
+	envKargs          = "KARGS_APPEND_STANZA"
+
+	ociDefaultIgnition  = "ignition.platform.id=oci"
+	qemuDefaultIgnition = "ignition.platform.id=qemu"
 )
 
 // CreateOptions are the options for the create image command
 type CreateOptions struct {
 	// IgnitionProvider is the provider type for ignition
 	IgnitionProvider string
+
+	// KernelArguments is any extra kernel command line arguments to append
+	KernelArguments string
 
 	// ProviderConfigPath is the path for the provider config (e.g ~/.oci/config)
 	ProviderConfigPath string
@@ -54,8 +62,9 @@ type CreateOptions struct {
 }
 
 type providerFuncs struct {
-	createConfigMap func(string, string) *corev1.ConfigMap
-	createImage     func(*copyConfig) error
+	defaultIgnitionStanza string
+	createConfigMap       func(string, string) *corev1.ConfigMap
+	createImage           func(*copyConfig) error
 }
 
 // Create creates a qcow2 image for the specified provider type
@@ -102,12 +111,22 @@ func Create(startConfig *otypes.Config, clusterConfig *otypes.ClusterConfig, opt
 		return err
 	}
 
+	ignitionStanza := options.IgnitionProvider
+	if ignitionStanza == "" {
+		ignitionStanza = providers[options.ProviderType].defaultIgnitionStanza
+	}
+
+	kargsStanza, err := generateKernelArgsStanza(options.KernelArguments)
+	if err != nil {
+		return err
+	}
+
 	// create the pod, first delete the pod if it exists
 	if err := k8s.DeletePod(kubeClient, namespace, podName); err != nil {
 		return err
 	}
 	defer k8s.DeletePod(kubeClient, namespace, podName)
-	if err := createPod(kubeClient, namespace, podName, constants.DefaultPodImage, options.ProviderType); err != nil {
+	if err := createPod(kubeClient, namespace, podName, constants.DefaultPodImage, ignitionStanza, kargsStanza); err != nil {
 		return err
 	}
 
@@ -142,7 +161,7 @@ func Create(startConfig *otypes.Config, clusterConfig *otypes.ClusterConfig, opt
 }
 
 // createPod creates a pod that mounts the config map with the same name as the pod
-func createPod(client kubernetes.Interface, namespace string, name string, imageName string, providerType string) error {
+func createPod(client kubernetes.Interface, namespace string, name string, imageName string, ignitionStanza string, kargs string) error {
 	privileged := true
 	builderVolumeName := "builder"
 	hostVolumeName := "host-root"
@@ -167,7 +186,8 @@ func createPod(client kubernetes.Interface, namespace string, name string, image
 					Image:   imageName,
 					Command: []string{"sleep", "10d"},
 					Env: []corev1.EnvVar{
-						{Name: envProviderType, Value: providerType},
+						{Name: envIgnitionStanza, Value: ignitionStanza},
+						{Name: envKargs, Value: kargs},
 					},
 					SecurityContext: &corev1.SecurityContext{
 						Privileged: &privileged,
@@ -258,12 +278,14 @@ func createOciImage(cc *copyConfig) error {
 
 var providers = map[string]providerFuncs{
 	ProviderTypeOCI: providerFuncs{
-		createConfigMap: createOciConfigMap,
-		createImage:     createOciImage,
+		defaultIgnitionStanza: ociDefaultIgnition,
+		createConfigMap:       createOciConfigMap,
+		createImage:           createOciImage,
 	},
 	ProviderTypeOstree: providerFuncs{
-		createConfigMap: createOstreeConfigMap,
-		createImage:     createOstreeImage,
+		defaultIgnitionStanza: qemuDefaultIgnition,
+		createConfigMap:       createOstreeConfigMap,
+		createImage:           createOstreeImage,
 	},
 }
 
@@ -286,4 +308,50 @@ func createImage(cc *copyConfig) error {
 	}
 
 	return pf.createImage(cc)
+}
+
+// generateKernelArgsStanza creates a sed command that appends
+// a string to the end of the kernel command line in a grub
+// entry
+func generateKernelArgsStanza(args string) (string, error) {
+	// Sed supports arbitrary expression separators for
+	// replacement expressions.  The input string can have
+	// any set of characters in it.  Find a character that is
+	// not in the string and use that.  The reason for doing
+	// this is that there is no need to try escaping characters
+	// in the input string.  The downside is that it cannot
+	// support the case where the input string contains all
+	// printable characters.  That seems unlikely.
+
+	// If there are no args, then there is no stanza
+	if args == "" {
+		return "", nil
+	}
+
+	// This is the range of printable characters, more or less.
+	var bang byte = 33
+	var tilde byte = 126
+
+	sep := ""
+	for sepByte := bang; sepByte <= tilde; sepByte = sepByte + 1 {
+		sepCandidate := string([]byte{sepByte})
+
+		if !strings.Contains(args, sepCandidate) {
+			sep = sepCandidate
+			break
+		}
+	}
+
+	// No acceptable character was found.  It's hard to imagine this
+	// actually happening, but stranger things do.
+	if sep == "" {
+		return "", fmt.Errorf("extra kernel arguments use all printable characters")
+	}
+
+	// Build a sed command that appends something to the end of the options
+	// line.  Assume that the separator is '|' and the input string is
+	// "foo bar baz".  The result will be:
+	//
+	// /^options / s|$| foo bar baz|
+	return fmt.Sprintf("/^options / s%s$%s %s%s", sep, sep, args, sep), nil
 }

--- a/pkg/commands/image/create/scripts.go
+++ b/pkg/commands/image/create/scripts.go
@@ -93,7 +93,10 @@ while mount -o rw /dev/nbd0p2 $HOST_BUILD_DIR/p2; [[ $? -ne 0 ]]; do
 done
 
 # Change the ignition platform ID
-sed -i "s/ignition.platform.id=qemu/ignition.platform.id=${IGNITION_PROVIDER_TYPE}/g" $HOST_BUILD_DIR/p2/loader/entries/ostree-1-ock.conf
+sed -i "s/ignition.platform.id=qemu/${IGNITION_STANZA}/g" $HOST_BUILD_DIR/p2/loader/entries/ostree-1-ock.conf
+if [ -n "${KARGS_APPEND_STANZA}" ]; then
+	sed -i "${KARGS_APPEND_STANZA}" $HOST_BUILD_DIR/p2/loader/entries/ostree-1-ock.conf
+fi
 
 # Change the UUIDs
 sed -i "s/$OLD_ROOT_UUID/$ROOT_UUID/g" $HOST_BUILD_DIR/p2/loader/entries/ostree-1-ock.conf

--- a/pkg/commands/image/create/scripts.go
+++ b/pkg/commands/image/create/scripts.go
@@ -93,7 +93,7 @@ while mount -o rw /dev/nbd0p2 $HOST_BUILD_DIR/p2; [[ $? -ne 0 ]]; do
 done
 
 # Change the ignition platform ID
-sed -i "s/ignition.platform.id=qemu/${IGNITION_STANZA}/g" $HOST_BUILD_DIR/p2/loader/entries/ostree-1-ock.conf
+sed -i "s/ignition.platform.id=qemu/ignition.platform.id=${IGNITION_PROVIDER_TYPE}/g" $HOST_BUILD_DIR/p2/loader/entries/ostree-1-ock.conf
 if [ -n "${KARGS_APPEND_STANZA}" ]; then
 	sed -i "${KARGS_APPEND_STANZA}" $HOST_BUILD_DIR/p2/loader/entries/ostree-1-ock.conf
 fi


### PR DESCRIPTION
Allows users to specify custom ignition providers and extra kernel arguments.

Examples:
```
# Make the image
[opc@dkrasins-dev-ol9 ocne]$ ./out/linux_amd64/ocne image create -i 'mycoolprovider' -K 'my cool args'
INFO[2024-10-30T17:52:24Z] Creating Image                               
INFO[2024-10-30T17:52:24Z] Preparing pod used to create image           
INFO[2024-10-30T17:52:29Z] Waiting for pod ocne-system/ocne-image-builder to be ready: ok 
INFO[2024-10-30T17:52:29Z] Getting local boot image for architecture: amd64 
INFO[2024-10-30T17:52:50Z] Uploading boot image to pod ocne-system/ocne-image-builder: ok 
INFO[2024-10-30T17:53:45Z] Downloading boot image from pod ocne-system/ocne-image-builder: ok 
INFO[2024-10-30T17:53:45Z] New boot image was created successfully at /home/opc/.ocne/images/boot.qcow2-1.30-amd64.oci 

# Connect and mount it
[opc@dkrasins-dev-ol9 ocne]$ sudo qemu-nbd --connect /dev/nbd15 /home/opc/.ocne/images/boot.qcow2-1.30-amd64.oci
[opc@dkrasins-dev-ol9 ocne]$ sudo mount /dev/nbd15p2 /tmp/mounts/

# Hey look, the edits are there!
[opc@dkrasins-dev-ol9 ocne]$ sudo cat /tmp/mounts/loader/entries/ostree-1-ock.conf
title Oracle Linux Server 8.10 17 (ostree:0)
version 1
options rw ip=dhcp rd.neednet=1 ignition.platform.id=mycoolprovider ignition.firstboot=1 systemd.firstboot=off crashkernel=auto console=ttyS0 root=UUID=b8a7ecd6-9ee1-486d-9512-d47d9606a06c ostree=/ostree/boot.1/ock/cb6b0cdaba879d285d6449d43fee00eab56c0ac1dcaf5d02a562d6a773d1829b/0 rd.timeout=120 my cool args
linux /ostree/ock-cb6b0cdaba879d285d6449d43fee00eab56c0ac1dcaf5d02a562d6a773d1829b/vmlinuz-5.15.0-209.161.7.2.el8uek.x86_64
initrd /ostree/ock-cb6b0cdaba879d285d6449d43fee00eab56c0ac1dcaf5d02a562d6a773d1829b/initramfs-5.15.0-209.161.7.2.el8uek.x86_64.img

# Disconnect everything
[opc@dkrasins-dev-ol9 ocne]$ sudo umount /tmp/mounts
[opc@dkrasins-dev-ol9 ocne]$ sudo qemu-nbd --disconnect /dev/nbd15
/dev/nbd15 disconnected
```

```
# Don't allow silliness
[opc@dkrasins-dev-ol9 ocne]$ ./out/linux_amd64/ocne image create -i 'ignition.mycoolprovider' -K '`1234567890-=qwertyuiop[]\asdfghjkl;zxcvbnm,./~!@#$%^&*()_+QWERTYUIOP{}|ASDFGHJKL:"ZXCVBNM<>?'\'
INFO[2024-10-30T18:00:04Z] Creating Image                               
INFO[2024-10-30T18:00:04Z] Preparing pod used to create image           
ERRO[2024-10-30T18:00:04Z] extra kernel arguments use all printable characters
```