### PR TITLE
140 add version and commit information to ocne cli and fix run directive

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,7 @@ GOPATH ?= $(shell go env GOPATH)
 
 CATALOG_REPO=https://github.com/oracle-cne/catalog.git
 MAKEFILE_DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
-OCNE_DIR:=github.com/oracle-cne$(shell echo ${MAKEFILE_DIR} | sed 's/.*github.com//')
-INFO_DIR:=/cmd/info
+INFO_DIR:=${MAKEFILE_DIR}/cmd/info
 CLONE_DIR:=${MAKEFILE_DIR}/temp-clone-dir
 BUILD_DIR:=build
 OUT_DIR:=out
@@ -61,7 +60,7 @@ help: ## Display this help.
 
 .PHONY: run
 run:
-	$(GO) run ${GOPATH}/src/${OCNE_DIR}/main.go
+	$(GO) run -trimpath -ldflags "${CLI_GO_LDFLAGS}" ./...
 #
 # Go build related tasks
 #

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ GIT_COMMIT:=$(shell git rev-parse HEAD)
 BUILD_DATE:=$(shell date +"%Y-%m-%dT%H:%M:%SZ")
 CLI_VERSION:=$(shell grep Version: ${MAKEFILE_DIR}/buildrpm/ocne.spec | cut -d ' ' -f 2)-$(shell grep Release: Version: ${MAKEFILE_DIR}/buildrpm/ocne.spec | cut -d ' ' -f 2 | cut -d '%' -f 1)
 
-ifneq (,$(findstring linux-gnu,$(OSTYPE)))
+ifneq (,$(findstring linux-gnu,${OSTYPE}))
 	CLI_VERSION=$(shell rpmspec -q --queryformat='%{VERSION}-%{RELEASE}' ${MAKEFILE_DIR}/buildrpm/ocne.spec)
 endif
 ifndef RELEASE_BRANCH

--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,8 @@ GOPATH ?= $(shell go env GOPATH)
 
 CATALOG_REPO=https://github.com/oracle-cne/catalog.git
 MAKEFILE_DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
-OCNE_DIR:=github.com$(shell echo ${MAKEFILE_DIR} | sed 's/.*github.com//')
-INFO_DIR:=${OCNE_DIR}/cmd/info
+OCNE_DIR:=github.com/oracle-cne$(shell echo ${MAKEFILE_DIR} | sed 's/.*github.com//')
+INFO_DIR:=/cmd/info
 CLONE_DIR:=${MAKEFILE_DIR}/temp-clone-dir
 BUILD_DIR:=build
 OUT_DIR:=out

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ GOPATH ?= $(shell go env GOPATH)
 
 CATALOG_REPO=https://github.com/oracle-cne/catalog.git
 MAKEFILE_DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
-OCNE_DIR:=github.com/oracle-cne$(shell echo ${MAKEFILE_DIR} | sed 's/.*github.com//')
+OCNE_DIR:=github.com$(shell echo ${MAKEFILE_DIR} | sed 's/.*github.com//')
 INFO_DIR:=${OCNE_DIR}/cmd/info
 CLONE_DIR:=${MAKEFILE_DIR}/temp-clone-dir
 BUILD_DIR:=build
@@ -31,6 +31,7 @@ NAME:=ocne
 
 GIT_COMMIT:=$(shell git rev-parse HEAD)
 BUILD_DATE:=$(shell date +"%Y-%m-%dT%H:%M:%SZ")
+CLI_VERSION:=$(shell grep version: ${OCNE_DIR}/buildrpm/ocne.spec | cut -d ' ' -f 2)
 
 ifdef RELEASE_VERSION
 	CLI_VERSION=${RELEASE_VERSION}
@@ -60,7 +61,7 @@ help: ## Display this help.
 
 .PHONY: run
 run:
-	$(GO) run -ldflags "${CLI_GO_LDFLAGS}" ${GOPATH}/src/${OCNE_DIR}/main.go
+	$(GO) run ${GOPATH}/src/${OCNE_DIR}/main.go
 #
 # Go build related tasks
 #

--- a/Makefile
+++ b/Makefile
@@ -31,8 +31,9 @@ NAME:=ocne
 
 GIT_COMMIT:=$(shell git rev-parse HEAD)
 BUILD_DATE:=$(shell date +"%Y-%m-%dT%H:%M:%SZ")
-CLI_VERSION:=$(shell grep Version: ${MAKEFILE_DIR}/buildrpm/ocne.spec | cut -d ' ' -f 2)-$(shell grep Release: Version: ${MAKEFILE_DIR}/buildrpm/ocne.spec | cut -d ' ' -f 2 | cut -d '%' -f 1)
-ifneq (,$(findstring linux-gnu,$(OSTYPE)))
+CLI_VERSION:=$(shell grep Version: ${MAKEFILE_DIR}/buildrpm/ocne.spec | cut -d ' ' -f 2)-$(shell grep Release: ${MAKEFILE_DIR}/buildrpm/ocne.spec | cut -d ' ' -f 2 | cut -d '%' -f 1)
+OS:=$(shell uname)
+ifeq ($(OS), Linux)
 	CLI_VERSION=$(shell rpmspec -q --queryformat='%{VERSION}-%{RELEASE}' ${MAKEFILE_DIR}/buildrpm/ocne.spec)
 endif
 ifndef RELEASE_BRANCH

--- a/Makefile
+++ b/Makefile
@@ -33,8 +33,8 @@ GIT_COMMIT:=$(shell git rev-parse HEAD)
 BUILD_DATE:=$(shell date +"%Y-%m-%dT%H:%M:%SZ")
 CLI_VERSION:=$(shell grep Version: ${MAKEFILE_DIR}/buildrpm/ocne.spec | cut -d ' ' -f 2)-$(shell grep Release: Version: ${MAKEFILE_DIR}/buildrpm/ocne.spec | cut -d ' ' -f 2 | cut -d '%' -f 1)
 
-ifdef RELEASE_VERSION
-	CLI_VERSION=${RELEASE_VERSION}
+ifneq (,$(findstring linux-gnu,$(OSTYPE)))
+	CLI_VERSION=$(shell rpmspec -q --queryformat='%{VERSION}-%{RELEASE}' ${MAKEFILE_DIR}/buildrpm/ocne.spec)
 endif
 ifndef RELEASE_BRANCH
 	RELEASE_BRANCH=$(shell git rev-parse --abbrev-ref HEAD)

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ NAME:=ocne
 
 GIT_COMMIT:=$(shell git rev-parse HEAD)
 BUILD_DATE:=$(shell date +"%Y-%m-%dT%H:%M:%SZ")
-CLI_VERSION:=$(shell grep Version: ${OCNE_DIR}/buildrpm/ocne.spec | cut -d ' ' -f 2)
+CLI_VERSION:=$(shell grep Version: ${MAKEFILE_DIR}/buildrpm/ocne.spec | cut -d ' ' -f 2)
 
 ifdef RELEASE_VERSION
 	CLI_VERSION=${RELEASE_VERSION}

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ NAME:=ocne
 
 GIT_COMMIT:=$(shell git rev-parse HEAD)
 BUILD_DATE:=$(shell date +"%Y-%m-%dT%H:%M:%SZ")
-CLI_VERSION:=$(shell grep version: ${OCNE_DIR}/buildrpm/ocne.spec | cut -d ' ' -f 2)
+CLI_VERSION:=$(shell grep Version: ${OCNE_DIR}/buildrpm/ocne.spec | cut -d ' ' -f 2)
 
 ifdef RELEASE_VERSION
 	CLI_VERSION=${RELEASE_VERSION}

--- a/Makefile
+++ b/Makefile
@@ -32,8 +32,7 @@ NAME:=ocne
 GIT_COMMIT:=$(shell git rev-parse HEAD)
 BUILD_DATE:=$(shell date +"%Y-%m-%dT%H:%M:%SZ")
 CLI_VERSION:=$(shell grep Version: ${MAKEFILE_DIR}/buildrpm/ocne.spec | cut -d ' ' -f 2)-$(shell grep Release: Version: ${MAKEFILE_DIR}/buildrpm/ocne.spec | cut -d ' ' -f 2 | cut -d '%' -f 1)
-OSTYPE:=$(shell echo ${OSTYPE})
-ifneq (,$(findstring linux-gnu,${OSTYPE}))
+ifneq (,$(findstring linux-gnu,$(OSTYPE)))
 	CLI_VERSION=$(shell rpmspec -q --queryformat='%{VERSION}-%{RELEASE}' ${MAKEFILE_DIR}/buildrpm/ocne.spec)
 endif
 ifndef RELEASE_BRANCH

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,8 @@ GOPATH ?= $(shell go env GOPATH)
 
 CATALOG_REPO=https://github.com/oracle-cne/catalog.git
 MAKEFILE_DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
-INFO_DIR:=${MAKEFILE_DIR}/cmd/info
+OCNE_DIR:=github.com$(shell echo ${MAKEFILE_DIR} | sed 's/.*github.com//')
+INFO_DIR:=${OCNE_DIR}/cmd/info
 CLONE_DIR:=${MAKEFILE_DIR}/temp-clone-dir
 BUILD_DIR:=build
 OUT_DIR:=out

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ GOPATH ?= $(shell go env GOPATH)
 CATALOG_REPO=https://github.com/oracle-cne/catalog.git
 MAKEFILE_DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 OCNE_DIR:=github.com/oracle-cne$(shell echo ${MAKEFILE_DIR} | sed 's/.*github.com//')
+INFO_DIR:=${OCNE_DIR}/cmd/info
 CLONE_DIR:=${MAKEFILE_DIR}/temp-clone-dir
 BUILD_DIR:=build
 OUT_DIR:=out
@@ -42,6 +43,9 @@ DIST_DIR:=dist
 ENV_NAME=ocne
 GO=GO111MODULE=on GOPRIVATE=github.com/oracle-cne/ocne go
 
+CLI_GO_LDFLAGS=-X '${INFO_DIR}.gitCommit=${GIT_COMMIT}' -X '${INFO_DIR}.buildDate=${BUILD_DATE}' -X '${INFO_DIR}.cliVersion=${CLI_VERSION}'
+
+
 export GOCOVERDIR
 export BATS_RESULT_DIR
 
@@ -56,7 +60,7 @@ help: ## Display this help.
 
 .PHONY: run
 run:
-	$(GO) run ${GOPATH}/src/${OCNE_DIR}/main.go
+	$(GO) run -ldflags "${CLI_GO_LDFLAGS}" ${GOPATH}/src/${OCNE_DIR}/main.go
 #
 # Go build related tasks
 #
@@ -77,11 +81,11 @@ $(CHART_BUILD_OUT_DIR): $(CHART_BUILD_DIR)
 
 .PHONY: build-cli
 build-cli: $(CHART_EMBED) $(PLATFORM_OUT_DIR) ## Build CLI for the current system and architecture
-	$(GO) build -trimpath -o $(OUT_DIR)/$(shell go env GOOS)_$(shell go env GOARCH) ./...
+	$(GO) build -trimpath -ldflags "${CLI_GO_LDFLAGS}" -o $(OUT_DIR)/$(shell go env GOOS)_$(shell go env GOARCH) ./...
 
 # Build an instrumented CLI for the current system and architecture
 build-cli-instrumented: $(CHARTS_EMBED) $(PLATFORM_INSTRUMENTED_OUT_DIR)
-	$(GO) build -cover -trimpath -o $(OUT_DIR)/$(shell go env GOOS)_$(shell go env GOARCH)_instrumented ./...
+	$(GO) build -cover -trimpath -ldflags "${CLI_GO_LDFLAGS}" -o $(OUT_DIR)/$(shell go env GOOS)_$(shell go env GOARCH)_instrumented ./...
 
 .PHONY: cli
 cli: build-cli ## Build and install the CLI

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ NAME:=ocne
 GIT_COMMIT:=$(shell git rev-parse HEAD)
 BUILD_DATE:=$(shell date +"%Y-%m-%dT%H:%M:%SZ")
 CLI_VERSION:=$(shell grep Version: ${MAKEFILE_DIR}/buildrpm/ocne.spec | cut -d ' ' -f 2)-$(shell grep Release: Version: ${MAKEFILE_DIR}/buildrpm/ocne.spec | cut -d ' ' -f 2 | cut -d '%' -f 1)
-
+OSTYPE:=$(shell echo ${OSTYPE})
 ifneq (,$(findstring linux-gnu,${OSTYPE}))
 	CLI_VERSION=$(shell rpmspec -q --queryformat='%{VERSION}-%{RELEASE}' ${MAKEFILE_DIR}/buildrpm/ocne.spec)
 endif

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ NAME:=ocne
 
 GIT_COMMIT:=$(shell git rev-parse HEAD)
 BUILD_DATE:=$(shell date +"%Y-%m-%dT%H:%M:%SZ")
-CLI_VERSION:=$(shell grep Version: ${MAKEFILE_DIR}/buildrpm/ocne.spec | cut -d ' ' -f 2)
+CLI_VERSION:=$(shell grep Version: ${MAKEFILE_DIR}/buildrpm/ocne.spec | cut -d ' ' -f 2)-$(shell grep Release: Version: ${MAKEFILE_DIR}/buildrpm/ocne.spec | cut -d ' ' -f 2 | cut -d '%' -f 1)
 
 ifdef RELEASE_VERSION
 	CLI_VERSION=${RELEASE_VERSION}

--- a/buildrpm/ocne.spec
+++ b/buildrpm/ocne.spec
@@ -20,6 +20,7 @@ BuildRequires: btrfs-progs-devel
 BuildRequires: device-mapper-devel
 BuildRequires: libassuan-devel
 BuildRequires: yq
+BuildRequires: rpm-build
 Requires: bash-completion
 Requires: containers-common
 

--- a/cmd/info/info.go
+++ b/cmd/info/info.go
@@ -13,8 +13,8 @@ import (
 
 const (
 	CommandName = "info"
-	helpShort   = "Display usage information"
-	helpLong    = `Display usage information for options that are not available from individual commands.`
+	helpShort   = "Display usage and build information"
+	helpLong    = `Display usage information for options that are not available from individual commands along with build information.`
 	helpExample = `
 ocne info
 `
@@ -66,9 +66,9 @@ func RunCmd(cmd *cobra.Command) error {
 	fmt.Printf("CLI Info\n")
 
 	infoArgs := map[string]string{
-		"CLI_VERSION": cliVersion,
-		"BUILD_DATE":  buildDate,
-		"GIT_COMMIT":  gitCommit,
+		"Version":   cliVersion,
+		"BuildDate": buildDate,
+		"GitCommit": gitCommit,
 	}
 
 	infoTable := uitable.New()

--- a/cmd/info/info.go
+++ b/cmd/info/info.go
@@ -61,6 +61,8 @@ func RunCmd(cmd *cobra.Command) error {
 	}
 	fmt.Println(table)
 
+	fmt.Println()
+
 	fmt.Printf("CLI Info\n")
 
 	infoArgs := map[string]string{
@@ -75,9 +77,9 @@ func RunCmd(cmd *cobra.Command) error {
 
 	infoTable.AddRow("Name", "Value")
 	for name, value := range infoArgs {
-		table.AddRow(name, value)
+		infoTable.AddRow(name, value)
 	}
-	fmt.Println(table)
+	fmt.Println(infoTable)
 	return nil
 
 }

--- a/cmd/info/info.go
+++ b/cmd/info/info.go
@@ -13,8 +13,8 @@ import (
 
 const (
 	CommandName = "info"
-	helpShort   = "Display usage and build information"
-	helpLong    = `Display usage information for options that are not available from individual commands along with build information.`
+	helpShort   = "Displays version and setting information"
+	helpLong    = `Displays settings for options that are not available from individual commands along with version information.`
 	helpExample = `
 ocne info
 `

--- a/cmd/info/info.go
+++ b/cmd/info/info.go
@@ -24,6 +24,11 @@ var cliVersion string
 var buildDate string
 var gitCommit string
 
+type infoStruct struct {
+	name  string
+	value string
+}
+
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   CommandName,
@@ -46,10 +51,10 @@ func RunCmd(cmd *cobra.Command) error {
 
 	fmt.Printf("CLI Info\n")
 
-	infoArgs := map[string]string{
-		"Version":   cliVersion,
-		"BuildDate": buildDate,
-		"GitCommit": gitCommit,
+	infoArgs := []infoStruct{
+		{name: "Version", value: cliVersion},
+		{name: "BuildDate", value: buildDate},
+		{name: "GitCommit", value: gitCommit},
 	}
 
 	infoTable := uitable.New()
@@ -57,8 +62,8 @@ func RunCmd(cmd *cobra.Command) error {
 	infoTable.MaxColWidth = 50
 
 	infoTable.AddRow("Name", "Value")
-	for name, value := range infoArgs {
-		infoTable.AddRow(name, value)
+	for _, pair := range infoArgs {
+		infoTable.AddRow(pair.name, pair.value)
 	}
 	fmt.Println(infoTable)
 
@@ -66,10 +71,10 @@ func RunCmd(cmd *cobra.Command) error {
 
 	fmt.Printf("Environment Variables\n")
 
-	envVars := map[string]string{
-		"OCNE_DEFAULTS": "Sets the location of the default configuration file.",
-		"KUBECONFIG":    "Sets the location of the kubeconfig file. This behaves the same way as the --kubeconfig option for most ocne commands.",
-		"EDITOR":        "Sets the default document editor.",
+	envVars := []infoStruct{
+		{name: "OCNE_DEFAULTS", value: "Sets the location of the default configuration file."},
+		{name: "KUBECONFIG", value: "Sets the location of the kubeconfig file. This behaves the same way as the --kubeconfig option for most ocne commands."},
+		{name: "EDITOR", value: "Sets the default document editor."},
 	}
 
 	table := uitable.New()
@@ -77,8 +82,8 @@ func RunCmd(cmd *cobra.Command) error {
 	table.MaxColWidth = 50
 
 	table.AddRow("Name", "Description", "Current Value")
-	for envVar, description := range envVars {
-		table.AddRow(envVar, description, os.Getenv(envVar))
+	for _, pair := range envVars {
+		table.AddRow(pair.name, pair.value, os.Getenv(pair.name))
 	}
 	fmt.Println(table)
 

--- a/cmd/info/info.go
+++ b/cmd/info/info.go
@@ -20,6 +20,10 @@ ocne info
 `
 )
 
+var cliVersion string
+var buildDate string
+var gitCommit string
+
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   CommandName,
@@ -57,6 +61,23 @@ func RunCmd(cmd *cobra.Command) error {
 	}
 	fmt.Println(table)
 
+	fmt.Printf("CLI Info\n")
+
+	infoArgs := map[string]string{
+		"CLI_VERSION": cliVersion,
+		"BUILD_DATE":  buildDate,
+		"GIT_COMMIT":  gitCommit,
+	}
+
+	infoTable := uitable.New()
+	infoTable.Wrap = true
+	infoTable.MaxColWidth = 50
+
+	infoTable.AddRow("Name", "Value")
+	for name, value := range infoArgs {
+		table.AddRow(name, value)
+	}
+	fmt.Println(table)
 	return nil
 
 }

--- a/cmd/info/info.go
+++ b/cmd/info/info.go
@@ -43,25 +43,6 @@ func NewCmd() *cobra.Command {
 
 // RunCmd runs the "ocne info" command
 func RunCmd(cmd *cobra.Command) error {
-	fmt.Printf("Environment Variables\n")
-
-	envVars := map[string]string{
-		"OCNE_DEFAULTS": "Sets the location of the default configuration file.",
-		"KUBECONFIG":    "Sets the location of the kubeconfig file. This behaves the same way as the --kubeconfig option for most ocne commands.",
-		"EDITOR":        "Sets the default document editor.",
-	}
-
-	table := uitable.New()
-	table.Wrap = true
-	table.MaxColWidth = 50
-
-	table.AddRow("Name", "Description", "Current Value")
-	for envVar, description := range envVars {
-		table.AddRow(envVar, description, os.Getenv(envVar))
-	}
-	fmt.Println(table)
-
-	fmt.Println()
 
 	fmt.Printf("CLI Info\n")
 
@@ -80,6 +61,27 @@ func RunCmd(cmd *cobra.Command) error {
 		infoTable.AddRow(name, value)
 	}
 	fmt.Println(infoTable)
+
+	fmt.Println()
+
+	fmt.Printf("Environment Variables\n")
+
+	envVars := map[string]string{
+		"OCNE_DEFAULTS": "Sets the location of the default configuration file.",
+		"KUBECONFIG":    "Sets the location of the kubeconfig file. This behaves the same way as the --kubeconfig option for most ocne commands.",
+		"EDITOR":        "Sets the default document editor.",
+	}
+
+	table := uitable.New()
+	table.Wrap = true
+	table.MaxColWidth = 50
+
+	table.AddRow("Name", "Description", "Current Value")
+	for envVar, description := range envVars {
+		table.AddRow(envVar, description, os.Getenv(envVar))
+	}
+	fmt.Println(table)
+
 	return nil
 
 }

--- a/doc/manpages/ocne-info.md
+++ b/doc/manpages/ocne-info.md
@@ -1,0 +1,34 @@
+OCNE-INFO 1 "November 2024" Linux "User Manuals"
+================================================
+
+NAME
+----
+
+ocne info - Manage nodes inside a Kubernetes cluster
+
+SYNOPSIS
+--------
+
+`ocne` `info`
+
+DESCRIPTION
+-----------
+
+`ocne` `info` displays settings for options that are not available from individual commands along with version information.
+
+ENVIRONMENT
+-----------
+
+`OCNE_DEFAULTS`
+Command displays the current value of this environment variable.
+
+`KUBECONFIG`
+Command displays the current value of this environment variable.
+
+`EDITOR`
+Command displays the current value of this environment variable.
+
+AUTHOR
+------
+
+George Aeillo <george.f.aeilloi@oracle.com>

--- a/doc/manpages/ocne-info.md
+++ b/doc/manpages/ocne-info.md
@@ -31,4 +31,4 @@ Command displays the current value of this environment variable.
 AUTHOR
 ------
 
-George Aeillo <george.f.aeilloi@oracle.com>
+George Aeillo <george.f.aeillo@oracle.com>


### PR DESCRIPTION
First pass of adding version and commit information to the CLI 

Example Output: 
```
./ocne info
CLI Info
Name     	Value                                   
Version  	2.0.4-3.el8                             
BuildDate	2024-11-05T09:43:59Z                    
GitCommit	55d88909e7629339d2428adc1a3bc92af22669dd

Environment Variables
Name         	Description                                       	Current Value
OCNE_DEFAULTS	Sets the location of the default configuration    	             
             	file.                                             	             
KUBECONFIG   	Sets the location of the kubeconfig file. This    	             
             	behaves the same way as the --kubeconfig option   	             
             	for most ocne commands.                           	             
EDITOR       	Sets the default document editor.    
```

```
./ocne info --help
Displays settings for options that are not available from individual commands along with version information.

```