### PR TITLE
Fix nodes not being skipped during cluster info

### DIFF
--- a/pkg/commands/cluster/info/info.go
+++ b/pkg/commands/cluster/info/info.go
@@ -143,6 +143,10 @@ func validate(o *Options) error {
 
 // extractNodeInfo extracts info from node dump files.  If the node directory doesn't exist then return nil
 func extractNodeInfo(skipNodes bool, outDir string, nodeName string) (*nodeDumpData, error) {
+	// This checks to see whether the node data should be skipped
+	if skipNodes {
+		return nil, nil
+	}
 	// This checks to see both filepaths, covering the cases where a redacted dump has occurred and when a non-redacted dump has occurred
 	nodeDir, err := getNodePath(outDir, nodeName)
 	if err != nil {


### PR DESCRIPTION
In this PR, I fix the issue where nodes were not being skipped during the output of the `ocne cluster info` command. 

```
./ocne cluster info -s
Cluster Summary:
  control plane nodes: 1
  worker nodes: 0
  nodes with available updates: 0

Nodes:
  Name                  Role            State   Version         Update Available
  ----                  ----            -----   -------         ----------------
  ocne-test-node  control plane   Ready   v1.30.3+1.el8   false

```
```
./ocne cluster info   
INFO[2024-11-05T11:28:47-05:00] Collecting node data                         
Cluster Summary:
  control plane nodes: 1
  worker nodes: 0
  nodes with available updates: 0

Nodes:
  Name                  Role            State   Version         Update Available
  ----                  ----            -----   -------         ----------------
  ocne-test-node control plane   Ready   v1.30.3+1.el8   false


Node: ocne-test-node
  Registry and tag for ostree patch images:
    registry: test-registry
    tag: 1.30
    transport: ostree-unverified-registry
  Ostree deployments:
      ock test-deployment-staged (staged)
    * ock test-deployment
```