### PR TITLE
Fix cluster dump to have the correct cluster-info.out file, when nodes are skipped

### DIFF
--- a/pkg/commands/cluster/dump/capture/clusterinfo.go
+++ b/pkg/commands/cluster/dump/capture/clusterinfo.go
@@ -16,7 +16,7 @@ import (
 
 const clusterInfoFile = "cluster-info.out"
 
-func CaptureClusterInfo(kubeClient kubernetes.Interface, outDir string, skipRedact bool) {
+func CaptureClusterInfo(skipNodes bool, kubeClient kubernetes.Interface, outDir string, skipRedact bool) {
 	b := bytes.Buffer{}
 	writer := bufio.NewWriter(&b)
 
@@ -25,6 +25,7 @@ func CaptureClusterInfo(kubeClient kubernetes.Interface, outDir string, skipReda
 		KubeClient:  kubeClient,
 		RootDumpDir: outDir,
 		Writer:      writer,
+		SkipNodes:   skipNodes,
 	})
 	if err != nil {
 		log.Errorf(err.Error())

--- a/pkg/commands/cluster/dump/dump.go
+++ b/pkg/commands/cluster/dump/dump.go
@@ -13,13 +13,13 @@ import (
 	"path/filepath"
 	"sync"
 
-	log "github.com/sirupsen/logrus"
-	"k8s.io/apimachinery/pkg/util/uuid"
 	"github.com/oracle-cne/ocne/pkg/commands/cluster/dump/capture"
 	"github.com/oracle-cne/ocne/pkg/constants"
 	"github.com/oracle-cne/ocne/pkg/file"
 	"github.com/oracle-cne/ocne/pkg/k8s"
 	"github.com/oracle-cne/ocne/pkg/k8s/client"
+	log "github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/util/uuid"
 )
 
 // Options are the options for the dump command
@@ -141,7 +141,7 @@ func Dump(o Options) error {
 	if !o.SkipCluster {
 		// cluster info cannot be captured until all the node files have been dumped
 		// so do it after all the goroutines are done
-		capture.CaptureClusterInfo(kubeClient, o.OutDir, o.SkipRedact)
+		capture.CaptureClusterInfo(o.SkipNodes, kubeClient, o.OutDir, o.SkipRedact)
 	}
 	if o.ArchiveFile != "" {
 		err = CreateReportArchive(o.OutDir, o.ArchiveFile)


### PR DESCRIPTION
In this PR, I fix the `cluster dump` command to have the correct output when nodes are skipped 

```
cat cluster-info.out 
Cluster Summary:
  control plane nodes: 1
  worker nodes: 0
  nodes with available updates: 0

Nodes:
  Name                  Role            State   Version         Update Available
  ----                  ----            -----   -------         ----------------
  REDACTED-dd54744c     control plane   Ready   v1.30.3+1.el8   false

```