### PR TITLE
Fix Other Bugs in Cluster Dump and Cluster Info Regarding Nodes

### DIFF
--- a/pkg/commands/cluster/dump/capture/clusterinfo.go
+++ b/pkg/commands/cluster/dump/capture/clusterinfo.go
@@ -16,7 +16,7 @@ import (
 
 const clusterInfoFile = "cluster-info.out"
 
-func CaptureClusterInfo(skipNodes bool, kubeClient kubernetes.Interface, outDir string, skipRedact bool) {
+func CaptureClusterInfo(skipNodes bool, kubeClient kubernetes.Interface, outDir string, skipRedact bool, nodeNames []string) {
 	b := bytes.Buffer{}
 	writer := bufio.NewWriter(&b)
 
@@ -26,6 +26,7 @@ func CaptureClusterInfo(skipNodes bool, kubeClient kubernetes.Interface, outDir 
 		RootDumpDir: outDir,
 		Writer:      writer,
 		SkipNodes:   skipNodes,
+		NodeNames:   nodeNames,
 	})
 	if err != nil {
 		log.Errorf(err.Error())

--- a/pkg/commands/cluster/dump/dump.go
+++ b/pkg/commands/cluster/dump/dump.go
@@ -147,7 +147,7 @@ func Dump(o Options) error {
 	if !o.SkipCluster {
 		// cluster info cannot be captured until all the node files have been dumped
 		// so do it after all the goroutines are done
-		capture.CaptureClusterInfo(o.SkipNodes, kubeClient, o.OutDir, o.SkipRedact)
+		capture.CaptureClusterInfo(o.SkipNodes, kubeClient, o.OutDir, o.SkipRedact, nodeNames)
 	}
 	if o.ArchiveFile != "" {
 		err = CreateReportArchive(o.OutDir, o.ArchiveFile)

--- a/pkg/commands/cluster/dump/dump.go
+++ b/pkg/commands/cluster/dump/dump.go
@@ -97,7 +97,7 @@ func Dump(o Options) error {
 	}
 
 	// If the user specifies a node name that is not present, return
-	_, err = determineNodeNames(o, kubeClient)
+	nodeNames, err := determineNodeNames(o, kubeClient)
 	if err != nil {
 		return err
 	}
@@ -116,7 +116,7 @@ func Dump(o Options) error {
 		wg.Add(1)
 		log.Infof("Collecting node data")
 		go func() {
-			err := dumpNodes(o, kubeClient)
+			err := dumpNodes(o, kubeClient, nodeNames)
 			if err != nil {
 				log.Errorf("Error dumping nodes: %s", err.Error())
 			}

--- a/pkg/commands/cluster/dump/dump.go
+++ b/pkg/commands/cluster/dump/dump.go
@@ -96,6 +96,12 @@ func Dump(o Options) error {
 		return err
 	}
 
+	// If the user specifies a node name that is not present, return
+	_, err = determineNodeNames(o, kubeClient)
+	if err != nil {
+		return err
+	}
+
 	// Populate the map of the nodes and their hashes, in case sanitization is needed later
 	err = populateNodeMap(kubeClient)
 	if err != nil {

--- a/pkg/commands/cluster/dump/node.go
+++ b/pkg/commands/cluster/dump/node.go
@@ -34,12 +34,6 @@ func dumpNodes(o Options, kubeClient kubernetes.Interface) error {
 	podSet := make(map[string]*k8s.PodOptions)
 	namespace := constants.OCNESystemNamespace
 
-	// resolves the name
-	nodeNames, err := determineNodeNames(o, kubeClient)
-	if err != nil {
-		return err
-	}
-
 	// create the configmap with the scripts that will run on the pod. First delete cm if exists.
 	// the pod mounts this configmap
 	if err := k8s.DeleteConfigmap(kubeClient, namespace, cmName); err != nil {

--- a/pkg/commands/cluster/dump/node.go
+++ b/pkg/commands/cluster/dump/node.go
@@ -29,7 +29,7 @@ const (
 )
 
 // dumpNodes dumps data from the specified nodes in the cluster
-func dumpNodes(o Options, kubeClient kubernetes.Interface) error {
+func dumpNodes(o Options, kubeClient kubernetes.Interface, nodeNames []string) error {
 	// create a set to keep track of which nodes are dumped
 	podSet := make(map[string]*k8s.PodOptions)
 	namespace := constants.OCNESystemNamespace

--- a/pkg/commands/cluster/info/info.go
+++ b/pkg/commands/cluster/info/info.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/utils/strings/slices"
 	"os"
 	"path/filepath"
 )
@@ -112,6 +113,11 @@ func Info(o Options) error {
 		return err
 	}
 	for i, node := range nodeList.Items {
+		// This is a check that filters out node names that haven't been specified by the user
+		// When the nodeNames list is empty, all nodes are assumed to be captured, so this check is skipped
+		if !slices.Contains(o.NodeNames, node.Name) && len(o.NodeNames) > 0 {
+			continue
+		}
 		nodeDumpInfo, err := extractNodeInfo(o.SkipNodes, o.RootDumpDir, node.Name)
 		if err != nil {
 			return err

--- a/pkg/commands/cluster/info/info.go
+++ b/pkg/commands/cluster/info/info.go
@@ -113,14 +113,14 @@ func Info(o Options) error {
 		return err
 	}
 	for i, node := range nodeList.Items {
+		var nodeDumpInfo *nodeDumpData
 		// This is a check that filters out node names that haven't been specified by the user
 		// When the nodeNames list is empty, all nodes are assumed to be captured, so this check is skipped
-		if !slices.Contains(o.NodeNames, node.Name) && len(o.NodeNames) > 0 {
-			continue
-		}
-		nodeDumpInfo, err := extractNodeInfo(o.SkipNodes, o.RootDumpDir, node.Name)
-		if err != nil {
-			return err
+		if slices.Contains(o.NodeNames, node.Name) || len(o.NodeNames) == 0 {
+			nodeDumpInfo, err = extractNodeInfo(o.SkipNodes, o.RootDumpDir, node.Name)
+			if err != nil {
+				return err
+			}
 		}
 
 		cp, role := k8s.GetRole(&node)


### PR DESCRIPTION
In this PR, I fixed bugs that occurred when the `cluster dump `and` cluster info` commands were not validating nodes and outputting incorrect information when an incorrect node list was given. I also fixed a bug that occurred when incorrect information was displayed when a partial, but valid node list was given. 

Example Where Error Is Thrown After Non-Existent Node is specified:
```
./ocne cluster info -N actual-node, non-existent-node                     
ERRO[2024-11-06T10:24:59-05:00] The following node resources do not exist: [non-existent-node] 
```

Example where the output is presented correctly after a partial list of nodes is specified:

```
./ocne cluster info -N ocne-worker-node
INFO[2024-11-06T10:34:29-05:00] Collecting node data                         
Cluster Summary:
  control plane nodes: 1
  worker nodes: 1
  nodes with available updates: 0

Nodes:
  Name                  Role            State   Version         Update Available
  ----                  ----            -----   -------         ----------------
  ocne-control-node  control plane   Ready   v1.29.3+3.el8   false
  ocne-worker-node      worker          Ready   v1.29.3+3.el8   false

Node: ocne-worker-1
  Registry and tag for ostree patch images:
  ...
  Ostree deployments:
  ...

```

