### PR TITLE
Introduced environment variable CATALOG_BRANCH  to customize catalog branch. Fixed typo in dependency of target build-cli-instrumented.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,8 @@ CHART_GIT_DIR:=build/charts
 
 CHART_EMBED:=pkg/catalog/embedded/charts
 
+CATALOG_BRANCH?=release/2.0
+
 TEST_PATTERN:=.*
 TEST_FILTERS:=
 TEST_DIR:=$(OUT_DIR)/tests
@@ -75,7 +77,7 @@ $(CHART_EMBED): $(CHART_BUILD_OUT_DIR)
 	cp $(CHART_BUILD_OUT_DIR)/* $@
 
 $(CHART_BUILD_DIR): $(BUILD_DIR)
-	git clone -b release/2.0  $(CATALOG_REPO) $@
+	git clone -b ${CATALOG_BRANCH}  $(CATALOG_REPO) $@
 
 $(CHART_BUILD_OUT_DIR): $(CHART_BUILD_DIR)
 	cd $< && make
@@ -85,7 +87,7 @@ build-cli: $(CHART_EMBED) $(PLATFORM_OUT_DIR) ## Build CLI for the current syste
 	$(GO) build -trimpath -ldflags "${CLI_GO_LDFLAGS}" -o $(OUT_DIR)/$(shell go env GOOS)_$(shell go env GOARCH) ./...
 
 # Build an instrumented CLI for the current system and architecture
-build-cli-instrumented: $(CHARTS_EMBED) $(PLATFORM_INSTRUMENTED_OUT_DIR)
+build-cli-instrumented: $(CHART_EMBED) $(PLATFORM_INSTRUMENTED_OUT_DIR)
 	$(GO) build -cover -trimpath -ldflags "${CLI_GO_LDFLAGS}" -o $(OUT_DIR)/$(shell go env GOOS)_$(shell go env GOARCH)_instrumented ./...
 
 .PHONY: cli


### PR DESCRIPTION
Introduced environment variable CATALOG_BRANCH  to customize catalog branch when building ocne cli. Example:
```shell
CATALOG_BRANCH="27-istio-1.21" make clean cli
```

Fixed typo in dependency of make target `build-cli-instrumented`. Otherwise below command would fail.
```shell
$ make clean build-cli-instrumented 
rm -rf pkg/catalog/embedded/charts
rm -rf build/charts
rm -rf build
rm -rf out
mkdir -p out/linux_amd64_instrumented
GO111MODULE=on GOPRIVATE=github.com/oracle-cne/ocne go build -cover -trimpath -ldflags "-X 'github.com/home/opc/projects/work/oracle-cne/ocne/cmd/info.gitCommit=20d48f48c6eeb727aaba5a73e4026e8d5761991f' -X 'github.com/home/opc/projects/work/oracle-cne/ocne/cmd/info.buildDate=2024-11-09T01:45:05Z' -X 'github.com/home/opc/projects/work/oracle-cne/ocne/cmd/info.cliVersion=2.0.4-3.el9'" -o out/linux_amd64_instrumented ./...
pkg/catalog/embedded/embedded.go:16:12: pattern all:charts: no matching files found
make: *** [Makefile:91: build-cli-instrumented] Error 1
``` 