### PR TITLE
Enable 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ GOPATH ?= $(shell go env GOPATH)
 
 CATALOG_REPO=https://github.com/oracle-cne/catalog.git
 MAKEFILE_DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
+INFO_DIR:=github.com/oracle-cne/ocne/cmd/info
 CLONE_DIR:=${MAKEFILE_DIR}/temp-clone-dir
 BUILD_DIR:=build
 OUT_DIR:=out
@@ -80,12 +81,10 @@ $(CHART_BUILD_OUT_DIR): $(CHART_BUILD_DIR)
 
 .PHONY: build-cli
 build-cli: $(CHART_EMBED) $(PLATFORM_OUT_DIR) ## Build CLI for the current system and architecture
-    INFO_DIR:=$(shell go list ./... | grep cmd/info)
 	$(GO) build -trimpath -ldflags "${CLI_GO_LDFLAGS}" -o $(OUT_DIR)/$(shell go env GOOS)_$(shell go env GOARCH) ./...
 
 # Build an instrumented CLI for the current system and architecture
 build-cli-instrumented: $(CHARTS_EMBED) $(PLATFORM_INSTRUMENTED_OUT_DIR)
-    INFO_DIR:=$(shell go list ./... | grep cmd/info)
 	$(GO) build -cover -trimpath -ldflags "${CLI_GO_LDFLAGS}" -o $(OUT_DIR)/$(shell go env GOOS)_$(shell go env GOARCH)_instrumented ./...
 
 .PHONY: cli

--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,7 @@ GOPATH ?= $(shell go env GOPATH)
 
 CATALOG_REPO=https://github.com/oracle-cne/catalog.git
 MAKEFILE_DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
-OCNE_DIR:=github.com$(shell echo ${MAKEFILE_DIR} | sed 's/.*github.com//')
-INFO_DIR:=${OCNE_DIR}/cmd/info
+INFO_DIR:=$(shell go list ./... | grep cmd/info)
 CLONE_DIR:=${MAKEFILE_DIR}/temp-clone-dir
 BUILD_DIR:=build
 OUT_DIR:=out

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,6 @@ GOPATH ?= $(shell go env GOPATH)
 
 CATALOG_REPO=https://github.com/oracle-cne/catalog.git
 MAKEFILE_DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
-INFO_DIR:=$(shell go list ./... | grep cmd/info)
 CLONE_DIR:=${MAKEFILE_DIR}/temp-clone-dir
 BUILD_DIR:=build
 OUT_DIR:=out
@@ -81,10 +80,12 @@ $(CHART_BUILD_OUT_DIR): $(CHART_BUILD_DIR)
 
 .PHONY: build-cli
 build-cli: $(CHART_EMBED) $(PLATFORM_OUT_DIR) ## Build CLI for the current system and architecture
+    INFO_DIR:=$(shell go list ./... | grep cmd/info)
 	$(GO) build -trimpath -ldflags "${CLI_GO_LDFLAGS}" -o $(OUT_DIR)/$(shell go env GOOS)_$(shell go env GOARCH) ./...
 
 # Build an instrumented CLI for the current system and architecture
 build-cli-instrumented: $(CHARTS_EMBED) $(PLATFORM_INSTRUMENTED_OUT_DIR)
+    INFO_DIR:=$(shell go list ./... | grep cmd/info)
 	$(GO) build -cover -trimpath -ldflags "${CLI_GO_LDFLAGS}" -o $(OUT_DIR)/$(shell go env GOOS)_$(shell go env GOARCH)_instrumented ./...
 
 .PHONY: cli


### PR DESCRIPTION
In this PR, I changed the package path for the LDL flag to correspond to the go package directly, instead of trying to determine it from the user's file system. This allows it the `ocne info` command to work when the CLI is built on unique directories. 

Example, where path of repo is `~/ocne`
```
make build-cli 
...
GO111MODULE=on GOPRIVATE=github.com/oracle-cne/ocne go build -trimpath -ldflags "-X 'github.com/oracle-cne/ocne/cmd/info.gitCommit=9fca20175c0f24838f1ddb01c6a8f4b2ae69d581' -X 'github.com/oracle-cne/ocne/cmd/info.buildDate=2024-11-12T15:52:21Z' -X 'github.com/oracle-cne/ocne/cmd/info.cliVersion=2.0.4-3.el8'" -o out/linux_amd64 ./...
...
./ocne info
CLI Info
Name     	Value                                   
Version  	2.0.4-3.el8                             
BuildDate	2024-11-12T15:52:21Z                    
GitCommit	9fca20175c0f24838f1ddb01c6a8f4b2ae69d581
```

