### PR TITLE
Add YAML output  in cluster dump and analyze and remove managed fields by default 

### DIFF
--- a/cmd/cluster/analyze/analyze.go
+++ b/cmd/cluster/analyze/analyze.go
@@ -108,7 +108,6 @@ func dumpCluster(outDir string) error {
 	dumpOptions.IncludeConfigMap = true
 	dumpOptions.OutDir = outDir
 	dumpOptions.SkipRedact = true
-	dumpOptions.ToJSON = true
 
 	return dump.Dump(dumpOptions)
 }

--- a/cmd/cluster/analyze/analyze.go
+++ b/cmd/cluster/analyze/analyze.go
@@ -41,9 +41,8 @@ const (
 	flagVerboseShort = "v"
 	flagVerboseHelp  = "Display additional detailed information related to the analysis."
 
-	flagJSON      = "json"
-	flagJSONShort = "j"
-	flagJSONHelp  = "Used when the Kubernetes cluster dump being analyzed has resources in JSON format"
+	flagJSON     = "json"
+	flagJSONHelp = "Used when the Kubernetes cluster dump being analyzed has resources in JSON format"
 )
 
 var dumpOptions dump.Options
@@ -67,7 +66,7 @@ func NewCmd() *cobra.Command {
 	// Analyze options
 	cmd.Flags().StringVarP(&options.RootDumpDir, flagDumpDir, flagDumpDirShort, "", flagDumpDirHelp)
 	cmd.Flags().BoolVarP(&options.Verbose, flagVerbose, flagVerboseShort, false, flagVerboseHelp)
-	cmd.Flags().BoolVarP(&options.JSON, flagJSON, flagJSONShort, false, flagJSONHelp)
+	cmd.Flags().BoolVar(&options.JSON, flagJSON, false, flagJSONHelp)
 
 	// Dump options
 	cmd.Flags().BoolVarP(&dumpOptions.SkipNodes, flagSkipNodes, flagSkipNodesShort, false, flagSkipNodesHelp)

--- a/cmd/cluster/analyze/analyze.go
+++ b/cmd/cluster/analyze/analyze.go
@@ -7,12 +7,12 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/spf13/cobra"
-	"k8s.io/apimachinery/pkg/util/uuid"
 	"github.com/oracle-cne/ocne/pkg/cmdutil"
 	"github.com/oracle-cne/ocne/pkg/commands/cluster/analyze"
 	"github.com/oracle-cne/ocne/pkg/commands/cluster/dump"
 	"github.com/oracle-cne/ocne/pkg/file"
+	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/util/uuid"
 )
 
 const (
@@ -40,6 +40,10 @@ const (
 	flagVerbose      = "verbose"
 	flagVerboseShort = "v"
 	flagVerboseHelp  = "Display additional detailed information related to the analysis."
+
+	flagIsJSON      = "is-json"
+	flagIsJSONShort = "j"
+	flagIsJSONHelp  = "Used when the Kubernetes cluster dump being analyzed has resources in JSON format"
 )
 
 var dumpOptions dump.Options
@@ -63,6 +67,7 @@ func NewCmd() *cobra.Command {
 	// Analyze options
 	cmd.Flags().StringVarP(&options.RootDumpDir, flagDumpDir, flagDumpDirShort, "", flagDumpDirHelp)
 	cmd.Flags().BoolVarP(&options.Verbose, flagVerbose, flagVerboseShort, false, flagVerboseHelp)
+	cmd.Flags().BoolVarP(&options.IsJSON, flagIsJSON, flagIsJSONShort, false, flagIsJSONHelp)
 
 	// Dump options
 	cmd.Flags().BoolVarP(&dumpOptions.SkipNodes, flagSkipNodes, flagSkipNodesShort, false, flagSkipNodesHelp)
@@ -103,6 +108,7 @@ func dumpCluster(outDir string) error {
 	dumpOptions.IncludeConfigMap = true
 	dumpOptions.OutDir = outDir
 	dumpOptions.SkipRedact = true
+	dumpOptions.ToJSON = true
 
 	return dump.Dump(dumpOptions)
 }

--- a/cmd/cluster/analyze/analyze.go
+++ b/cmd/cluster/analyze/analyze.go
@@ -41,9 +41,9 @@ const (
 	flagVerboseShort = "v"
 	flagVerboseHelp  = "Display additional detailed information related to the analysis."
 
-	flagIsJSON      = "is-json"
-	flagIsJSONShort = "j"
-	flagIsJSONHelp  = "Used when the Kubernetes cluster dump being analyzed has resources in JSON format"
+	flagJSON      = "json"
+	flagJSONShort = "j"
+	flagJSONHelp  = "Used when the Kubernetes cluster dump being analyzed has resources in JSON format"
 )
 
 var dumpOptions dump.Options
@@ -67,7 +67,7 @@ func NewCmd() *cobra.Command {
 	// Analyze options
 	cmd.Flags().StringVarP(&options.RootDumpDir, flagDumpDir, flagDumpDirShort, "", flagDumpDirHelp)
 	cmd.Flags().BoolVarP(&options.Verbose, flagVerbose, flagVerboseShort, false, flagVerboseHelp)
-	cmd.Flags().BoolVarP(&options.IsJSON, flagIsJSON, flagIsJSONShort, false, flagIsJSONHelp)
+	cmd.Flags().BoolVarP(&options.JSON, flagJSON, flagJSONShort, false, flagJSONHelp)
 
 	// Dump options
 	cmd.Flags().BoolVarP(&dumpOptions.SkipNodes, flagSkipNodes, flagSkipNodesShort, false, flagSkipNodesHelp)

--- a/cmd/cluster/dump/dump.go
+++ b/cmd/cluster/dump/dump.go
@@ -87,9 +87,9 @@ const (
 	flagManagedShort = "f"
 	flagManagedHelp  = "Remove managedField data from Kubernetes resource output"
 
-	flagToJSON      = "to-json"
-	flagToJSONShort = "j"
-	flagToJSONHelp  = "Output Kubernetes resources in JSON format"
+	flagJSON      = "json"
+	flagJSONShort = "j"
+	flagJSONHelp  = "Output Kubernetes resources in JSON format"
 )
 
 func NewCmd() *cobra.Command {
@@ -119,7 +119,7 @@ func NewCmd() *cobra.Command {
 	cmd.Flags().BoolVarP(&options.SkipRedact, flagSkipRedaction, flagSkipRedactionShort, false, flagSkipRedactionHelp)
 	cmd.Flags().StringVarP(&options.ArchiveFile, flagGenerateArchive, flagGenerateArchiveShort, "", flagGenerateClusterHelp)
 	cmd.Flags().BoolVarP(&options.Managed, flagManaged, flagManagedShort, false, flagManagedHelp)
-	cmd.Flags().BoolVarP(&options.ToJSON, flagToJSON, flagToJSONShort, false, flagToJSONHelp)
+	cmd.Flags().BoolVarP(&options.JSON, flagJSON, flagJSONShort, false, flagJSONHelp)
 
 	cmd.MarkFlagsMutuallyExclusive(flagOut, flagGenerateArchive)
 	cmd.MarkFlagsMutuallyExclusive(flagSkipCluster, flagCurated)

--- a/cmd/cluster/dump/dump.go
+++ b/cmd/cluster/dump/dump.go
@@ -83,13 +83,11 @@ const (
 	flagGenerateArchiveShort = "z"
 	flagGenerateClusterHelp  = "Generate an archive instead of dumping files to an output directory.  The filename must end with .tgz or .tar.gz"
 
-	flagManaged      = "managed"
-	flagManagedShort = "f"
-	flagManagedHelp  = "Remove managedField data from Kubernetes resource output"
+	flagManaged     = "managed"
+	flagManagedHelp = "Remove managedField data from Kubernetes resource output"
 
-	flagJSON      = "json"
-	flagJSONShort = "j"
-	flagJSONHelp  = "Output Kubernetes resources in JSON format"
+	flagJSON     = "json"
+	flagJSONHelp = "Output Kubernetes resources in JSON format"
 )
 
 func NewCmd() *cobra.Command {
@@ -118,8 +116,8 @@ func NewCmd() *cobra.Command {
 	cmd.Flags().BoolVarP(&options.SkipPodLogs, flagSkipPodLogs, flagSkipPodLogsShort, false, flagSkipPodLogsHelp)
 	cmd.Flags().BoolVarP(&options.SkipRedact, flagSkipRedaction, flagSkipRedactionShort, false, flagSkipRedactionHelp)
 	cmd.Flags().StringVarP(&options.ArchiveFile, flagGenerateArchive, flagGenerateArchiveShort, "", flagGenerateClusterHelp)
-	cmd.Flags().BoolVarP(&options.Managed, flagManaged, flagManagedShort, false, flagManagedHelp)
-	cmd.Flags().BoolVarP(&options.JSON, flagJSON, flagJSONShort, false, flagJSONHelp)
+	cmd.Flags().BoolVar(&options.Managed, flagManaged, false, flagManagedHelp)
+	cmd.Flags().BoolVar(&options.JSON, flagJSON, false, flagJSONHelp)
 
 	cmd.MarkFlagsMutuallyExclusive(flagOut, flagGenerateArchive)
 	cmd.MarkFlagsMutuallyExclusive(flagSkipCluster, flagCurated)

--- a/cmd/cluster/dump/dump.go
+++ b/cmd/cluster/dump/dump.go
@@ -82,6 +82,14 @@ const (
 	flagGenerateArchive      = "generate-archive"
 	flagGenerateArchiveShort = "z"
 	flagGenerateClusterHelp  = "Generate an archive instead of dumping files to an output directory.  The filename must end with .tgz or .tar.gz"
+
+	flagManaged      = "managed"
+	flagManagedShort = "f"
+	flagManagedHelp  = "Remove managedField data from Kubernetes resource output"
+
+	flagToJSON      = "to-json"
+	flagToJSONShort = "j"
+	flagToJSONHelp  = "Output Kubernetes resources in JSON format"
 )
 
 func NewCmd() *cobra.Command {
@@ -110,6 +118,8 @@ func NewCmd() *cobra.Command {
 	cmd.Flags().BoolVarP(&options.SkipPodLogs, flagSkipPodLogs, flagSkipPodLogsShort, false, flagSkipPodLogsHelp)
 	cmd.Flags().BoolVarP(&options.SkipRedact, flagSkipRedaction, flagSkipRedactionShort, false, flagSkipRedactionHelp)
 	cmd.Flags().StringVarP(&options.ArchiveFile, flagGenerateArchive, flagGenerateArchiveShort, "", flagGenerateClusterHelp)
+	cmd.Flags().BoolVarP(&options.Managed, flagManaged, flagManagedShort, false, flagManagedHelp)
+	cmd.Flags().BoolVarP(&options.ToJSON, flagToJSON, flagToJSONShort, false, flagToJSONHelp)
 
 	cmd.MarkFlagsMutuallyExclusive(flagOut, flagGenerateArchive)
 	cmd.MarkFlagsMutuallyExclusive(flagSkipCluster, flagCurated)

--- a/doc/manpages/ocne-cluster.md
+++ b/doc/manpages/ocne-cluster.md
@@ -134,6 +134,12 @@ SUBCOMMANDS
     Dump manifests from a curated subset of cluster resources.  By default, 
     all cluster resources are dumped, except Secrets and ConfigMaps.
 
+  `--json`
+    Dump Kubernetes resources in JSON format. The default is false and dumps them in YAML format.
+
+  `--managed`
+    Include the managedFields data in the Kubernetes resources. The default is false.
+
 `-m, --include-configmaps`
     Include ConfigMaps in the cluster dump. The --all-resources flag must also be true. 
     The default is false.
@@ -230,6 +236,10 @@ SUBCOMMANDS
 
   `-d, --output-directory` *string*
   The output directory containing cluster dump data which will be analyzed.
+
+  `--json`
+  Analyze a cluster dump that has Kubernetes artifacts in JSON format. 
+  The default is false and it assumes that the resources are in YAML format.
 
 `  -s, --skip-nodes`
   Skip collecting node resources for the analysis, default is false. This is only valid for a live cluster analysis.

--- a/pkg/commands/cluster/analyze/analyze.go
+++ b/pkg/commands/cluster/analyze/analyze.go
@@ -28,8 +28,8 @@ type Options struct {
 	// Verbose controls displaying of analyze details like events
 	Verbose bool
 
-	// IsYaml indicates whether the Kubernetes resources in the cluster dump have Kubernetes json or yaml resources
-	IsJSON bool
+	// JSON indicates whether the Kubernetes resources in the cluster dump have Kubernetes Resources in JSON format
+	JSON bool
 }
 
 // Analyze analyzes a cluster dump
@@ -55,7 +55,7 @@ func Analyze(o Options) error {
 		nodesDir:       filepath.Join(dumpDir, "nodes"),
 		verbose:        o.Verbose,
 		writer:         os.Stdout,
-		isJSON:         o.IsJSON,
+		isJSON:         o.JSON,
 	}
 	if err := analyzeCluster(&p); err != nil {
 		// keep going if error

--- a/pkg/commands/cluster/analyze/analyze.go
+++ b/pkg/commands/cluster/analyze/analyze.go
@@ -57,6 +57,9 @@ func Analyze(o Options) error {
 		writer:         os.Stdout,
 		isJSON:         o.JSON,
 	}
+	if _, err := os.Stat(dumpDir); err != nil {
+		return err
+	}
 	if err := analyzeCluster(&p); err != nil {
 		// keep going if error
 		log.Errorf("Error analyzing cluster: %v", err)

--- a/pkg/commands/cluster/analyze/event.go
+++ b/pkg/commands/cluster/analyze/event.go
@@ -5,8 +5,8 @@ package analyze
 
 import (
 	"fmt"
-	v1 "k8s.io/api/core/v1"
 	"github.com/oracle-cne/ocne/pkg/commands/cluster/analyze/triage"
+	v1 "k8s.io/api/core/v1"
 	"os"
 	"regexp"
 )
@@ -14,8 +14,8 @@ import (
 var excludeRegexpr = []string{"Search Line limits were exceeded"}
 
 func analyzeEvents(p *analyzeParams) error {
-	// Read the events.json from each namespace directory into a map
-	evMap, err := readNamespacedJSONFiles[v1.EventList](p, "events.json")
+	// Read the events.json/yaml from each namespace directory into a map
+	evMap, err := readNamespacedJSONOrYAMLFiles[v1.EventList](p, "events")
 	if err != nil {
 		return err
 	}

--- a/pkg/commands/cluster/analyze/node.go
+++ b/pkg/commands/cluster/analyze/node.go
@@ -6,8 +6,8 @@ package analyze
 import (
 	"fmt"
 
-	v1 "k8s.io/api/core/v1"
 	"github.com/oracle-cne/ocne/pkg/commands/cluster/analyze/triage"
+	v1 "k8s.io/api/core/v1"
 )
 
 func analyzeNodes(p *analyzeParams) error {
@@ -16,8 +16,7 @@ func analyzeNodes(p *analyzeParams) error {
 }
 
 func analyzeClusterNodes(p *analyzeParams) error {
-	// Read the cluster wide nodes.json
-	nodeList, err := readClusterWideJSONFile[v1.NodeList](p, "nodes.json")
+	nodeList, err := readClusterWideJSONOrYAMLFile[v1.NodeList](p, "nodes")
 	if err != nil {
 		return err
 	}

--- a/pkg/commands/cluster/analyze/pod.go
+++ b/pkg/commands/cluster/analyze/pod.go
@@ -8,14 +8,14 @@ import (
 	"os"
 	"strings"
 
-	v1 "k8s.io/api/core/v1"
 	"github.com/oracle-cne/ocne/pkg/commands/cluster/analyze/triage"
 	"github.com/oracle-cne/ocne/pkg/constants"
+	v1 "k8s.io/api/core/v1"
 )
 
 func analyzePods(p *analyzeParams) error {
-	// Read the pods.json from each namespace directory into a map
-	podMap, err := readNamespacedJSONFiles[v1.PodList](p, "pods.json")
+	// Read the pods.json/yaml from each namespace directory into a map
+	podMap, err := readNamespacedJSONOrYAMLFiles[v1.PodList](p, "pods")
 	if err != nil {
 		return err
 	}

--- a/pkg/commands/cluster/analyze/types.go
+++ b/pkg/commands/cluster/analyze/types.go
@@ -28,4 +28,7 @@ type analyzeParams struct {
 
 	// writer that writes the analyzer output
 	writer io.Writer
+
+	// isJSON if the Kubernetes resources being analyzed are in JSON format
+	isJSON bool
 }

--- a/pkg/commands/cluster/dump/capture/capture.go
+++ b/pkg/commands/cluster/dump/capture/capture.go
@@ -34,6 +34,8 @@ type CaptureParams struct {
 	IncludeConfigMaps bool
 	SkipPodLogs       bool
 	Redact            bool
+	Managed           bool
+	ToJSON            bool
 }
 
 type PodLogs struct {
@@ -55,9 +57,9 @@ func CaptureCuratedResources(cp CaptureParams) error {
 
 	for _, ns := range cp.Namespaces {
 		// background goroutine will log any errors, but they are not fatal
-		captureByNamespace(&cs, cp.DynamicClient, filepath.Join(cp.ClusterDumpDir, namespacesDir, ns), ns, cp.Redact)
+		captureByNamespace(&cs, cp.DynamicClient, filepath.Join(cp.ClusterDumpDir, namespacesDir, ns), ns, cp.Redact, cp.Managed, cp.ToJSON)
 	}
-	captureClusterWide(&cs, cp.DynamicClient, filepath.Join(cp.ClusterDumpDir, clusterWideDir), cp.Redact)
+	captureClusterWide(&cs, cp.DynamicClient, filepath.Join(cp.ClusterDumpDir, clusterWideDir), cp.Redact, cp.Managed, cp.ToJSON)
 
 	// capture podLogs last
 	if !cp.SkipPodLogs {
@@ -86,9 +88,9 @@ func CaptureAllResources(cp CaptureParams) error {
 
 	for _, ns := range cp.Namespaces {
 		// background goroutine will log any errors, but they are not fatal
-		goCaptureDynamicRes(&cs, namespacedGVRS, cp.DynamicClient, filepath.Join(cp.ClusterDumpDir, namespacesDir, ns), ns, cp.Redact)
+		goCaptureDynamicRes(&cs, namespacedGVRS, cp.DynamicClient, filepath.Join(cp.ClusterDumpDir, namespacesDir, ns), ns, cp.Redact, cp.Managed, cp.ToJSON)
 	}
-	goCaptureDynamicRes(&cs, clusterGVRs, cp.DynamicClient, filepath.Join(cp.ClusterDumpDir, clusterWideDir), "", cp.Redact)
+	goCaptureDynamicRes(&cs, clusterGVRs, cp.DynamicClient, filepath.Join(cp.ClusterDumpDir, clusterWideDir), "", cp.Redact, cp.Managed, cp.ToJSON)
 
 	// capture podLogs last
 	if !cp.SkipPodLogs {

--- a/pkg/commands/cluster/dump/cluster.go
+++ b/pkg/commands/cluster/dump/cluster.go
@@ -37,7 +37,7 @@ func dumpCluster(o Options, cli kubernetes.Interface, dynCli dynamic.Interface) 
 		SkipPodLogs:       o.SkipPodLogs,
 		Redact:            !o.SkipRedact,
 		Managed:           o.Managed,
-		ToJSON:            o.ToJSON,
+		ToJSON:            o.JSON,
 	}
 	if o.CuratedResources {
 		if err = capture.CaptureCuratedResources(cp); err != nil {

--- a/pkg/commands/cluster/dump/cluster.go
+++ b/pkg/commands/cluster/dump/cluster.go
@@ -36,6 +36,8 @@ func dumpCluster(o Options, cli kubernetes.Interface, dynCli dynamic.Interface) 
 		IncludeConfigMaps: o.IncludeConfigMap,
 		SkipPodLogs:       o.SkipPodLogs,
 		Redact:            !o.SkipRedact,
+		Managed:           o.Managed,
+		ToJSON:            o.ToJSON,
 	}
 	if o.CuratedResources {
 		if err = capture.CaptureCuratedResources(cp); err != nil {

--- a/pkg/commands/cluster/dump/dump.go
+++ b/pkg/commands/cluster/dump/dump.go
@@ -66,8 +66,8 @@ type Options struct {
 	// Managed determines whether the managedField metadata is dumped with a resource
 	Managed bool
 
-	// ToJSON determines whether the Kubernetes resources should be outputted in JSON format
-	ToJSON bool
+	// JSON determines whether the Kubernetes resources should be outputted in JSON format
+	JSON bool
 }
 
 // Dump the cluster

--- a/pkg/commands/cluster/dump/dump.go
+++ b/pkg/commands/cluster/dump/dump.go
@@ -62,6 +62,12 @@ type Options struct {
 
 	// ArchiveFile is the file path of the archive file that will be generated
 	ArchiveFile string
+
+	// Managed determines whether the managedField metadata is dumped with a resource
+	Managed bool
+
+	// ToJSON determines whether the Kubernetes resources should be outputted in JSON format
+	ToJSON bool
 }
 
 // Dump the cluster


### PR DESCRIPTION
In this PR, I add support for YAML in the `cluster dump` and `analyze`, making it the default behavior, unless the -j is specified. With cluster `info`, a YAML dump is always used, it is also used when analyzing a live cluster. A bug was also fixed, where the `cluster analyze` command would not error if an incorrect path was given. The managed fields portion of Kubernetes resources was also removed by default. 

Example of output of the namespace resource list in default/YAML format with no managed Fields

```
./ocne cluster dump  -d  test-yaml-dump
INFO[2024-11-12T16:49:47-05:00] Collecting node data                         
INFO[2024-11-12T16:49:47-05:00] Collecting cluster data                      
INFO[2024-11-12T16:49:57-05:00] Cluster dump successfully completed 

cat /cluster/cluster-wide/namespaces.yaml
apiVersion: v1
items:
- apiVersion: v1
  kind: Namespace
  metadata:
    creationTimestamp: "2024-11-07T20:03:42Z"
    labels:
      kubernetes.io/metadata.name: default
    name: default
    resourceVersion: "16"
    uid: 86875dcb-0064-4161-bb64-2553960c9deb
  spec:
    finalizers:
    - kubernetes
  status:
    phase: Active
...
kind: NamespaceList
metadata:
  resourceVersion: "121952"

```
Example of analysis run on a live cluster
```
./ocne cluster analyze   
INFO[2024-11-12T16:47:41-05:00] Collecting node data                         

Cluster Nodes:
--------------
Cluster nodes are normal

Pods:
-----
Pods are normal

```

Example of output of the namespace resource list in JSON with format and managed Fields
```
./ocne cluster dump --json --managed -d ./test-json-dump
INFO[2024-11-12T16:49:47-05:00] Collecting node data                         
INFO[2024-11-12T16:49:47-05:00] Collecting cluster data                      
INFO[2024-11-12T16:49:57-05:00] Cluster dump successfully completed 
cat /cluster/cluster-wide/namespaces.json

    {
...
      "apiVersion": "v1",
      "kind": "Namespace",
      "metadata": {
        "creationTimestamp": "2024-11-07T20:03:42Z",
        "labels": {
          "kubernetes.io/metadata.name": "kube-node-lease"
        },
        "managedFields": [
          {
            "apiVersion": "v1",
            "fieldsType": "FieldsV1",
            "fieldsV1": {
              "f:metadata": {
                "f:labels": {
                  ".": {},
                  "f:kubernetes.io/metadata.name": {}
                }
              }
            },
            "manager": "kube-apiserver",
            "operation": "Update",
            "time": "2024-11-07T20:03:42Z"
          }
        ],
        "name": "kube-node-lease",
        "resourceVersion": "14",
        "uid": "e79acdfb-e92c-4abc-9c47-4dc09400468f"
      },
      "spec": {
        "finalizers": [
          "kubernetes"
        ]
      },
      "status": {
        "phase": "Active"
      }
    },
...
```

Example of analysis run on a cluster dump that has JSON and managed fields 
```
./ocne cluster analyze --json  -d ./test-json-dump                     

Cluster Nodes:
--------------
Cluster nodes are normal

Pods:
-----
Pods are normal

```

Example of analysis run on a cluster dump that has YAML and no managed fields (default output) 
```
./ocne cluster analyze -d  ./test-yaml-dump 

Cluster Nodes:
--------------
Cluster nodes are normal

Pods:
-----
Pods are normal

```

Example of analysis run on a cluster dump path that does not exist 
```
./ocne cluster analyze -d  ./test-does-not-exist
ERRO[2024-11-12T17:00:22-05:00] stat ./test-does-not-exist: no such file or directory 

```
