### PR TITLE
"ocne application update" command failing when install did not customize any helm values initially

### DIFF
--- a/pkg/helm/helmcli.go
+++ b/pkg/helm/helmcli.go
@@ -155,9 +155,6 @@ func GetValues(kubeInfo *client.KubeInfo, releaseName string, namespace string) 
 	if err != nil {
 		return nil, err
 	}
-	if vals == nil {
-		return nil, nil
-	}
 
 	yamlValues, err := yaml.Marshal(vals)
 	if err != nil {

--- a/pkg/helm/helmcli.go
+++ b/pkg/helm/helmcli.go
@@ -452,9 +452,11 @@ func GetReleaseValues(kubeInfo *client.KubeInfo, valueKeys []string, releaseName
 		if err != nil {
 			return map[string]interface{}{}, err
 		}
-		for _, valueKey := range valueKeys {
-			if mapVal, ok := valuesMap[valueKey]; ok {
-				values[valueKey] = mapVal
+		if valuesMap != nil {
+			for _, valueKey := range valueKeys {
+				if mapVal, ok := valuesMap[valueKey]; ok {
+					values[valueKey] = mapVal
+				}
 			}
 		}
 	}

--- a/pkg/helm/helmcli.go
+++ b/pkg/helm/helmcli.go
@@ -6,6 +6,7 @@ package helm
 import (
 	"fmt"
 	"io"
+	"maps"
 	"net/url"
 	"os"
 	"regexp"
@@ -210,10 +211,11 @@ func UpgradeChart(kubeInfo *client.KubeInfo, releaseName string, namespace strin
 		// Reuse the original set of input values as the base set of helm overrides
 		helmValues := map[string]interface{}{}
 		if !resetValues {
-			helmValues, err = GetValuesMap(kubeInfo, releaseName, namespace)
+			helmValuesTemp, err := GetValuesMap(kubeInfo, releaseName, namespace)
 			if err != nil {
 				return nil, err
 			}
+			maps.Copy(helmValues, helmValuesTemp)
 		}
 
 		// Append the new override values

--- a/pkg/helm/helmcli.go
+++ b/pkg/helm/helmcli.go
@@ -155,6 +155,9 @@ func GetValues(kubeInfo *client.KubeInfo, releaseName string, namespace string) 
 	if err != nil {
 		return nil, err
 	}
+	if vals == nil {
+		return nil, nil
+	}
 
 	yamlValues, err := yaml.Marshal(vals)
 	if err != nil {

--- a/pkg/helm/helmcli.go
+++ b/pkg/helm/helmcli.go
@@ -452,11 +452,9 @@ func GetReleaseValues(kubeInfo *client.KubeInfo, valueKeys []string, releaseName
 		if err != nil {
 			return map[string]interface{}{}, err
 		}
-		if valuesMap != nil {
-			for _, valueKey := range valueKeys {
-				if mapVal, ok := valuesMap[valueKey]; ok {
-					values[valueKey] = mapVal
-				}
+		for _, valueKey := range valueKeys {
+			if mapVal, ok := valuesMap[valueKey]; ok {
+				values[valueKey] = mapVal
 			}
 		}
 	}

--- a/pkg/helm/helmcli.go
+++ b/pkg/helm/helmcli.go
@@ -98,6 +98,10 @@ func GetValuesMap(kubeInfo *client.KubeInfo, releaseName string, namespace strin
 		return nil, err
 	}
 
+	if vals == nil {
+		vals = map[string]interface{}{}
+	}
+
 	return vals, nil
 }
 

--- a/pkg/helm/helmcli.go
+++ b/pkg/helm/helmcli.go
@@ -6,7 +6,6 @@ package helm
 import (
 	"fmt"
 	"io"
-	"maps"
 	"net/url"
 	"os"
 	"regexp"
@@ -211,11 +210,10 @@ func UpgradeChart(kubeInfo *client.KubeInfo, releaseName string, namespace strin
 		// Reuse the original set of input values as the base set of helm overrides
 		helmValues := map[string]interface{}{}
 		if !resetValues {
-			helmValuesTemp, err := GetValuesMap(kubeInfo, releaseName, namespace)
+			helmValues, err = GetValuesMap(kubeInfo, releaseName, namespace)
 			if err != nil {
 				return nil, err
 			}
-			maps.Copy(helmValues, helmValuesTemp)
 		}
 
 		// Append the new override values


### PR DESCRIPTION
"ocne application update" command failing when install did not customize any helm values initially.

Fixed map variable from becoming nil

```shell
$ ocne application update --release istiod --version 1.19.9 --catalog embedded --namespace istio-system --values - << EOF
> ownerName: helm
> EOF
INFO[2024-11-14T23:26:05Z] Updating release istiod                      
INFO[2024-11-14T23:26:05Z] Application updated successfully

$ ocne  application show --release istiod --namespace istio-system
ownerName: helm
----------------
NAME: istiod
NAMESPACE: istio-system
CHART: istiod
STATUS: deployed
REVISION: 3
APPVERSION: 1.19.9
``` 