### PR TITLE
Have ocne automatically show help in some use cases

### DIFF
--- a/cmd/application/application.go
+++ b/cmd/application/application.go
@@ -4,14 +4,13 @@
 package application
 
 import (
-	"os"
-
 	"github.com/oracle-cne/ocne/cmd/application/install"
 	"github.com/oracle-cne/ocne/cmd/application/list"
 	"github.com/oracle-cne/ocne/cmd/application/show"
 	"github.com/oracle-cne/ocne/cmd/application/template"
 	"github.com/oracle-cne/ocne/cmd/application/uninstall"
 	"github.com/oracle-cne/ocne/cmd/application/update"
+	"github.com/oracle-cne/ocne/cmd/common"
 	"github.com/oracle-cne/ocne/cmd/constants"
 	"github.com/oracle-cne/ocne/pkg/cmdutil"
 	log "github.com/sirupsen/logrus"
@@ -31,17 +30,10 @@ var kubeConfig string
 
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   CommandName,
-		Short: helpShort,
-		Long:  helpLong,
-		Args: func(cmd *cobra.Command, args []string) error {
-			if len(args) == 0 {
-				cmd.Help()
-				os.Exit(0)
-			}
-			cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs)
-			return nil
-		},
+		Use:       CommandName,
+		Short:     helpShort,
+		Long:      helpLong,
+		Args:      common.ArgsCheck,
 		ValidArgs: []string{install.CommandName, list.CommandName, show.CommandName, template.CommandName, uninstall.CommandName, update.CommandName},
 	}
 

--- a/cmd/application/application.go
+++ b/cmd/application/application.go
@@ -4,8 +4,8 @@
 package application
 
 import (
-	log "github.com/sirupsen/logrus"
-	"github.com/spf13/cobra"
+	"os"
+
 	"github.com/oracle-cne/ocne/cmd/application/install"
 	"github.com/oracle-cne/ocne/cmd/application/list"
 	"github.com/oracle-cne/ocne/cmd/application/show"
@@ -14,6 +14,8 @@ import (
 	"github.com/oracle-cne/ocne/cmd/application/update"
 	"github.com/oracle-cne/ocne/cmd/constants"
 	"github.com/oracle-cne/ocne/pkg/cmdutil"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
 )
 
 const (
@@ -29,10 +31,17 @@ var kubeConfig string
 
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:       CommandName,
-		Short:     helpShort,
-		Long:      helpLong,
-		Args:      cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
+		Use:   CommandName,
+		Short: helpShort,
+		Long:  helpLong,
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				cmd.Help()
+				os.Exit(0)
+			}
+			cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs)
+			return nil
+		},
 		ValidArgs: []string{install.CommandName, list.CommandName, show.CommandName, template.CommandName, uninstall.CommandName, update.CommandName},
 	}
 

--- a/cmd/catalog/catalog.go
+++ b/cmd/catalog/catalog.go
@@ -4,8 +4,6 @@
 package catalog
 
 import (
-	log "github.com/sirupsen/logrus"
-	"github.com/spf13/cobra"
 	"github.com/oracle-cne/ocne/cmd/catalog/add"
 	"github.com/oracle-cne/ocne/cmd/catalog/copy"
 	"github.com/oracle-cne/ocne/cmd/catalog/get"
@@ -13,8 +11,11 @@ import (
 	"github.com/oracle-cne/ocne/cmd/catalog/mirror"
 	"github.com/oracle-cne/ocne/cmd/catalog/remove"
 	"github.com/oracle-cne/ocne/cmd/catalog/search"
+	"github.com/oracle-cne/ocne/cmd/common"
 	"github.com/oracle-cne/ocne/cmd/constants"
 	"github.com/oracle-cne/ocne/pkg/cmdutil"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
 )
 
 const (
@@ -33,7 +34,7 @@ func NewCmd() *cobra.Command {
 		Use:       CommandName,
 		Short:     helpShort,
 		Long:      helpLong,
-		Args:      cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
+		Args:      common.ArgsCheck,
 		ValidArgs: []string{add.CommandName, get.CommandName, list.CommandName, mirror.CommandName, remove.CommandName, search.CommandName, copy.CommandName},
 	}
 

--- a/cmd/cluster/cluster.go
+++ b/cmd/cluster/cluster.go
@@ -16,6 +16,7 @@ import (
 	"github.com/oracle-cne/ocne/cmd/cluster/stage"
 	"github.com/oracle-cne/ocne/cmd/cluster/start"
 	"github.com/oracle-cne/ocne/cmd/cluster/template"
+	"github.com/oracle-cne/ocne/cmd/common"
 	"github.com/oracle-cne/ocne/cmd/constants"
 	"github.com/oracle-cne/ocne/pkg/cmdutil"
 	log "github.com/sirupsen/logrus"
@@ -38,7 +39,7 @@ func NewCmd() *cobra.Command {
 		Use:       CommandName,
 		Short:     helpShort,
 		Long:      helpLong,
-		Args:      cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
+		Args:      common.ArgsCheck,
 		ValidArgs: []string{analyze.CommandName, backup.CommandName, console.CommandName, dump.CommandName, info.CommandName, join.CommandName, delete.CommandName, template.CommandName, stage.CommandName},
 	}
 

--- a/cmd/common/common.go
+++ b/cmd/common/common.go
@@ -1,0 +1,21 @@
+// Copyright (c) 2024, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package common
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+// ArgsCheck - common function for checking args for commands that only have
+// sub-commands.  The help for the sub-command will be displayed if no args are passed.
+func ArgsCheck(cmd *cobra.Command, args []string) error {
+	if len(args) == 0 {
+		cmd.Help()
+		os.Exit(0)
+	}
+	cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs)
+	return nil
+}

--- a/cmd/image/image.go
+++ b/cmd/image/image.go
@@ -4,11 +4,12 @@
 package image
 
 import (
-	"github.com/spf13/cobra"
+	"github.com/oracle-cne/ocne/cmd/common"
 	"github.com/oracle-cne/ocne/cmd/constants"
 	"github.com/oracle-cne/ocne/cmd/image/create"
 	"github.com/oracle-cne/ocne/cmd/image/upload"
 	"github.com/oracle-cne/ocne/pkg/cmdutil"
+	"github.com/spf13/cobra"
 )
 
 const (
@@ -27,7 +28,7 @@ func NewCmd() *cobra.Command {
 		Use:       CommandName,
 		Short:     helpShort,
 		Long:      helpLong,
-		Args:      cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
+		Args:      common.ArgsCheck,
 		ValidArgs: []string{create.CommandName},
 	}
 

--- a/cmd/node/node.go
+++ b/cmd/node/node.go
@@ -4,11 +4,12 @@
 package node
 
 import (
-	log "github.com/sirupsen/logrus"
-	"github.com/spf13/cobra"
+	"github.com/oracle-cne/ocne/cmd/common"
 	"github.com/oracle-cne/ocne/cmd/constants"
 	"github.com/oracle-cne/ocne/cmd/node/update"
 	"github.com/oracle-cne/ocne/pkg/cmdutil"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
 )
 
 const (
@@ -27,7 +28,7 @@ func NewCmd() *cobra.Command {
 		Use:       CommandName,
 		Short:     helpShort,
 		Long:      helpLong,
-		Args:      cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
+		Args:      common.ArgsCheck,
 		ValidArgs: []string{update.CommandName},
 	}
 


### PR DESCRIPTION
See associated task for description.

Example of output with these changes:

```
$ ocne app
Manage ocne applications

Usage:
  ocne application [flags]
  ocne application [command]

Examples:

ocne application install


Available Commands:
  install     Install an application from an application catalog or install the built-in catalog
  list        List installed applications
  show        Show application details
  template    Generate an application configuration template
  uninstall   Uninstall an application.
  update      Update an application from an application catalog or update the built-in catalog

Flags:
  -h, --help                help for application
  -k, --kubeconfig string   the kubeconfig filepath

Global Flags:
  -l, --log-level string   Sets the log level.  Valid values are "error", "info", "debug", and "trace". (default "info")

Use "ocne application [command] --help" for more information about a command.
```