### PR TITLE
Improve error information when cluster fails to start for libvirt provider

### DIFF
--- a/pkg/cluster/driver/libvirt/libvirt.go
+++ b/pkg/cluster/driver/libvirt/libvirt.go
@@ -837,7 +837,7 @@ func (ld *LibvirtDriver) Start() (bool, bool, error) {
 		if isRunning {
 			ld.Infof("Cluster %s is running already", ld.Name)
 		} else {
-			log.Errorf("Failed to start cluster %s", ld.Name)
+			log.Errorf("Failed to start cluster %q. The libvirt domain %q is running.", ld.Name, firstControlPlaneNode)
 		}
 		return isRunning, false, err
 	} else if err != nil {

--- a/pkg/k8s/client/config.go
+++ b/pkg/k8s/client/config.go
@@ -5,6 +5,7 @@ package client
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -75,11 +76,19 @@ func GetKubeConfigLocation(kubeconfigPath string) (string, bool, error) {
 	}
 
 	if testKubeConfig := os.Getenv(EnvVarTestKubeConfig); len(testKubeConfig) > 0 {
-		return sanitizePath(testKubeConfig, false)
+		path, echo, err := sanitizePath(testKubeConfig, false)
+		if err != nil {
+			err = fmt.Errorf("Failed to access the kubeconfig set by the environment variable %s: ", EnvVarTestKubeConfig)
+		}
+		return path, echo, err
 	}
 
 	if kubeConfig := os.Getenv(EnvVarKubeConfig); len(kubeConfig) > 0 {
-		return sanitizePath(kubeConfig, false)
+		path, echo, err := sanitizePath(kubeConfig, false)
+		if err != nil {
+			err = fmt.Errorf("Failed to access the kubeconfig set by the environment variable %s: ", EnvVarKubeConfig)
+		}
+		return path, echo, err
 	}
 
 	if home := homedir.HomeDir(); home != "" {


### PR DESCRIPTION
Sample output:
```
$ ocne cluster start -u false
ERRO[2024-12-19T17:12:30-05:00] Failed to start cluster "ocne". The libvirt domain "ocne-control-plane-1" is running. 
ERRO[2024-12-19T17:12:30-05:00] stat /Users/mgianata/.kube/kubeconfig.ocne.local: no such file or directory 
```