### PR TITLE
implement olvm image create --type olvm

### DIFF
--- a/pkg/commands/image/create/create.go
+++ b/pkg/commands/image/create/create.go
@@ -230,6 +230,28 @@ func createPod(client kubernetes.Interface, namespace string, name string, image
 					},
 				},
 			},
+			Tolerations: []corev1.Toleration{
+				{
+					Key:      "node-role.kubernetes.io/control-plane",
+					Effect:   corev1.TaintEffectNoSchedule,
+					Operator: corev1.TolerationOpExists,
+				},
+				{
+					Key:      "node.kubernetes.io/not-ready",
+					Effect:   corev1.TaintEffectNoSchedule,
+					Operator: corev1.TolerationOpExists,
+				},
+				{
+					Key:      "node.kubernetes.io/unschedulable",
+					Effect:   corev1.TaintEffectNoSchedule,
+					Operator: corev1.TolerationOpExists,
+				},
+				{
+					Key:      "node.kubernetes.io/unreachable",
+					Effect:   corev1.TaintEffectNoSchedule,
+					Operator: corev1.TolerationOpExists,
+				},
+			},
 		},
 	}
 

--- a/pkg/commands/image/create/oci.go
+++ b/pkg/commands/image/create/oci.go
@@ -1,0 +1,54 @@
+// Copyright (c) 2024, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package create
+
+import (
+	"github.com/oracle-cne/ocne/pkg/k8s/kubectl"
+	log "github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func createOciConfigMap(namespace string, name string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Immutable: nil,
+		Data: map[string]string{
+			setProviderScriptName: setProviderScript,
+			modifyImageScriptName: modifyImageScript,
+			OciDhcpScriptPath:     OciDhcpScript,
+			OciDhclientScriptPath: OciDhclientScript,
+			OciDhclientPath:       OciDhclient,
+		},
+	}
+}
+
+func createOciImage(cc *copyConfig) error {
+	// copy the qcow2 image from the local system to the pod
+	kubectl.SetPipes(cc.KubectlConfig)
+	err := uploadImage(cc)
+	if err != nil {
+		return err
+	}
+
+	// run the script in the pod to change the provider in the qcow2 image
+	kubectl.SetPipes(cc.KubectlConfig)
+	if err := kubectl.RunScript(cc.KubectlConfig, cc.podName, imageMountPath, setProviderScriptName); err != nil {
+		return err
+	}
+
+	// copy boot image from pod to local system
+	kubectl.SetPipes(cc.KubectlConfig)
+	localBootImagePath, err := downloadImage(cc)
+	if err != nil {
+		return err
+	}
+
+	log.Infof("New boot image was created successfully at %s", localBootImagePath)
+	return nil
+}

--- a/pkg/commands/image/create/olvm.go
+++ b/pkg/commands/image/create/olvm.go
@@ -1,0 +1,51 @@
+// Copyright (c) 2024, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package create
+
+import (
+	"github.com/oracle-cne/ocne/pkg/k8s/kubectl"
+	log "github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func createOlvmImage(cc *copyConfig) error {
+	// copy the qcow2 image from the local system to the pod
+	kubectl.SetPipes(cc.KubectlConfig)
+	err := uploadImage(cc)
+	if err != nil {
+		return err
+	}
+
+	// run the script in the pod to change the provider in the qcow2 image
+	kubectl.SetPipes(cc.KubectlConfig)
+	if err := kubectl.RunScript(cc.KubectlConfig, cc.podName, imageMountPath, setOlvmProviderScriptName); err != nil {
+		return err
+	}
+
+	// copy boot image from pod to local system
+	kubectl.SetPipes(cc.KubectlConfig)
+	localBootImagePath, err := downloadImage(cc)
+	if err != nil {
+		return err
+	}
+
+	log.Infof("New boot image was created successfully at %s", localBootImagePath)
+	return nil
+}
+
+func createOlvmConfigMap(namespace string, name string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Immutable: nil,
+		Data: map[string]string{
+			setOlvmProviderScriptName: setOlvmProviderScript,
+			modifyOlvmImageScriptName: modifyOlvmImageScript,
+		},
+	}
+}

--- a/pkg/commands/image/create/olvm_scripts.go
+++ b/pkg/commands/image/create/olvm_scripts.go
@@ -1,0 +1,142 @@
+// Copyright (c) 2024, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package create
+
+const (
+	setOlvmProviderScriptName = "set-provider.sh"
+	modifyOlvmImageScriptName = "modify-image.sh"
+
+	// The setProvider script changes the ignition provider type inside the boot qcow2 image.
+	// The script runs both before, during, and after chroot.  The modprobe needs chroot to work
+	// and if qemu-nbd is not run in chroot then it cannot find the nbd device.
+	// The script first copies files to /hostroot so that they can be accessed after
+	// chroot is done.  The modify_image.sh script runs from chroot and does the modifications then
+	// exits chroot.  Finally, the script copies the modified boot.qcow2 from /hostroot to /tmp
+	// so that it can be downloaded by the client
+	setOlvmProviderScript = `#! /bin/bash
+set -e
+
+HOST_BUILD_DIR="/tmp/ocne-image-build"
+HOSTROOT_BUILD_DIR="/hostroot/tmp/ocne-image-build"
+MODIFY_IMAGE_SCRIPT=modify-image.sh
+
+# copy scripts and image to /hostroot so that they can be accessed once we do chroot
+# chroot is needed or else modprobe won't work (it cannot find libraries)
+# note that once we chroot the /tmp is different from the /tmp that is seen from the pod root
+mkdir -p $HOSTROOT_BUILD_DIR
+cp /ocne-image-build/..data/* $HOSTROOT_BUILD_DIR
+cp /tmp/boot.qcow2 $HOSTROOT_BUILD_DIR 
+
+# chroot and run the script to modify the image
+chroot /hostroot $HOST_BUILD_DIR/modify-image.sh
+
+# copy the modified image back to /tmp so the client can download it
+cp $HOSTROOT_BUILD_DIR/boot.qcow2 /tmp/boot.qcow2
+`
+
+	// This script modifies the image after chroot is done
+	modifyOlvmImageScript = `#! /bin/bash
+set -e
+HOST_BUILD_DIR="/tmp/ocne-image-build"
+
+# Use network device to access QCOW2 image and modify the ignition provider type using sed
+modprobe nbd max_part=16
+qemu-nbd --connect=/dev/nbd0 $HOST_BUILD_DIR/boot.qcow2
+mkdir -p $HOST_BUILD_DIR/p1
+mkdir -p $HOST_BUILD_DIR/p2
+mkdir -p $HOST_BUILD_DIR/p3
+
+partprobe
+
+# Stash the old UUIDs
+OLD_BOOT_UUID=$(blkid -o value -s UUID /dev/nbd0p2)
+OLD_ROOT_UUID=$(blkid -o value -s UUID /dev/nbd0p3)
+
+# Generate some new UUIDs for the XFS partitions
+i=0
+while xfs_admin -U generate /dev/nbd0p2; [[ $? -ne 0 ]]; do
+	sleep 2s
+	echo "Retrying UUID generation for /dev/nbd0p2"
+	((++i))
+	if [[ $i -eq 30 ]]; then
+		echo "Error generating UUID for /dev/nbd0p2"
+		exit 1
+	fi
+done
+
+i=0
+while xfs_admin -U generate /dev/nbd0p3; [[ $? -ne 0 ]]; do
+	sleep 2s
+	echo "Retrying UUID generation for /dev/nbd0p3"
+	((++i))
+	if [[ $i -eq 30 ]]; then
+		echo "Error generating UUID for /dev/nbd0p3"
+		exit 1
+	fi
+done
+
+# Get the new UUIDs
+BOOT_UUID=$(blkid -o value -s UUID /dev/nbd0p2)
+ROOT_UUID=$(blkid -o value -s UUID /dev/nbd0p3)
+
+# sometimes the mount fails because the kernel doesn't yet know about the partition, so retry
+i=0
+while mount -o rw /dev/nbd0p2 $HOST_BUILD_DIR/p2; [[ $? -ne 0 ]]; do
+        sleep 2s
+        echo "Retrying mount /dev/nbd0p2"
+        ((++i))
+        if [[ $i -eq 30 ]]; then
+                echo "Error mounting /dev/nbd0p2"
+                exit 1
+        fi
+done
+
+# Change the ignition platform ID
+sed -i "s/ignition.platform.id=qemu/ignition.platform.id=openstack/g" $HOST_BUILD_DIR/p2/loader/entries/ostree-1-ock.conf
+sed -i "s/console=ttyS0/console=tty0/g" $HOST_BUILD_DIR/p2/loader/entries/ostree-1-ock.conf
+if [ -n "${KARGS_APPEND_STANZA}" ]; then
+	sed -i "${KARGS_APPEND_STANZA}" $HOST_BUILD_DIR/p2/loader/entries/ostree-1-ock.conf
+fi
+
+# Change the UUIDs
+sed -i "s/$OLD_ROOT_UUID/$ROOT_UUID/g" $HOST_BUILD_DIR/p2/loader/entries/ostree-1-ock.conf
+
+# Get the ostree commit to deploy
+#
+# OSTREE_DEPLOY is preceeded with a '/', hence the
+# lack thereof in the pattern for OSTREE_DEPLOY_DIR
+OSTREE_DEPLOY=$(cat $HOST_BUILD_DIR/p2/loader/entries/ostree-1-ock.conf | grep -o 'ostree=[^ ]*' | cut -d= -f2)
+OSTREE_DEPLOY_DIR="$HOST_BUILD_DIR/p3$OSTREE_DEPLOY"
+
+umount $HOST_BUILD_DIR/p2
+
+# Change /etc/fstab
+# sometimes the mount fails because the kernel doesn't yet know about the partition, so retry
+i=0
+while mount -o rw /dev/nbd0p3 $HOST_BUILD_DIR/p3; [[ $? -ne 0 ]]; do
+        sleep 2s
+        echo "Retrying mount /dev/nbd0p3"
+        ((++i))
+        if [[ $i -eq 30 ]]; then
+                echo "Error mounting /dev/nbd0p3"
+                exit 1
+        fi
+done
+
+sed -i "s|UUID=[a-zA-z0-9-]* /[ \t]|UUID=$ROOT_UUID / |g" "$OSTREE_DEPLOY_DIR/etc/fstab"
+sed -i "s|UUID=[a-zA-z0-9-]* /boot[ \t]|UUID=$BOOT_UUID /boot |g" "$OSTREE_DEPLOY_DIR/etc/fstab"
+
+# Remove machine id
+find $HOST_BUILD_DIR/p3/ostree/deploy/ock/deploy -type f -iname machine-id | xargs -I {} rm {}
+
+umount $HOST_BUILD_DIR/p3
+
+# Set the UUIDs back
+#xfs_admin -U $OLD_BOOT_UUID /dev/nbd0p2
+#xfs_admin -U $OLD_ROOT_UUID /dev/nbd0p3
+
+# exit chroot so that the image can be copied to pod /tmp.  The client will download it after the script completes
+exit
+`
+)


### PR DESCRIPTION
This PR implements olvm image create --type olvm. 

changes:

1. add create olvm image logic in go
2. add create olvm script (derived from oci script)
3. moved create oci code to its own go file
4. updated olvm ignition code to fix service issues

The script is a subset of the --type oci script, where the kernel args have the ignition type is set to openstack, and the console=tty0

Also, when testing with the latest OCK images there were some issues related to services being disabled and starting too soon.  I had to disable several services, then re-enable some right before kubeadm service runs.  You can see that in the ignition.go code.  If I didn't disable these services temporarily, there was some sort of startup race condition where it took a very long time (maybe 10 min) for the first node to start, and the second node never started.  Now, with the current logic in place, everything is working fine with the image that i created.

Once you create an image, you must create a VM template with that new image and use it in cluster start.

**Create image**
```
ocne image create --type olvm --kubeconfig $KUBECONFIG
INFO[2024-12-19T13:58:53-05:00] Creating Image                               
INFO[2024-12-19T13:58:53-05:00] Preparing pod used to create image           
INFO[2024-12-19T13:58:58-05:00] Waiting for pod ocne-system/ocne-image-builder to be ready: ok 
INFO[2024-12-19T13:58:58-05:00] Getting local boot image for architecture: amd64 
INFO[2024-12-19T13:59:22-05:00] Uploading boot image to pod ocne-system/ocne-image-builder: ok 
INFO[2024-12-19T14:00:12-05:00] Downloading boot image from pod ocne-system/ocne-image-builder: ok 
INFO[2024-12-19T14:00:12-05:00] New boot image was created successfully at /Users/pmackin/.ocne/images/boot.qcow2-1.30-amd64.olvm 
```
**Upload using the image***
```
ocne image upload --type olvm --arch amd64 --file  /Users/pmackin/.ocne/images/boot.qcow2-1.30-amd64.olvm   --config /Users/pmackin/.ocne/olvm-gz-1cp-1w.yaml --kubeconfig /Users/pmackin/.kube/kubeconfig.ocne.local
INFO[2024-12-19T14:01:39-05:00] Starting uploaded OCK image `/Users/pmackin/.ocne/images/boot.qcow2-1.30-amd64.olvm` to disk `paul-1-ock-1.30` in storage domain `oblock` 
INFO[2024-12-19T14:01:39-05:00] Waiting for disk status to be OK             
INFO[2024-12-19T14:01:57-05:00] Waiting for image transfer phase transferring 
INFO[2024-12-19T14:08:07-05:00] Uploading image /Users/pmackin/.ocne/images/boot.qcow2-1.30-amd64.olvm with 2826436608 bytes to paul-1-ock-1.30: ok 
INFO[2024-12-19T14:08:12-05:00] Waiting for image transfer phase finished_success 
INFO[2024-12-19T14:08:25-05:00] Successfully uploaded OCK image   
```

**Create cluster using the image***
```
ocne cluster start  --kubeconfig=/Users/pmackin/.kube/kubeconfig.ocne.local --provider olvm  --cluster-name paul -c /Users/pmackin/.ocne/olvm-gz-1cp-1w-paul-template.yaml
INFO[2024-12-19T18:22:50-05:00] Installing cert-manager into cert-manager: ok 
INFO[2024-12-19T18:22:50-05:00] Installing core-capi into capi-system: ok 
INFO[2024-12-19T18:22:51-05:00] Installing olvm-capi into cluster-api-provider-olvm: ok 
INFO[2024-12-19T18:22:51-05:00] Installing bootstrap-capi into capi-kubeadm-bootstrap-system: ok 
INFO[2024-12-19T18:22:52-05:00] Installing control-plane-capi into capi-kubeadm-control-plane-system: ok 
INFO[2024-12-19T18:22:52-05:00] Waiting for Core Cluster API Controllers: ok 
INFO[2024-12-19T18:22:52-05:00] Waiting for Kubadm Control Plane Cluster API Controllers: ok 
INFO[2024-12-19T18:23:02-05:00] Waiting for Kubadm Boostrap Cluster API Controllers: ok 
INFO[2024-12-19T18:23:02-05:00] Waiting for Olvm Cluster API Controllers: ok 
INFO[2024-12-19T18:23:02-05:00] Applying Cluster API resources               
INFO[2024-12-19T18:23:03-05:00] Waiting for kubeconfig: ok       
INFO[2024-12-19T18:25:23-05:00] Waiting for the Kubernetes cluster to be ready: ok 
INFO[2024-12-19T18:25:23-05:00] Installing applications into workload cluster 
INFO[2024-12-19T18:25:29-05:00] Installing flannel into kube-flannel: ok 
INFO[2024-12-19T18:25:31-05:00] Installing ui into ocne-system: ok 
INFO[2024-12-19T18:25:32-05:00] Installing ocne-catalog into ocne-system: ok 
INFO[2024-12-19T18:25:32-05:00] Kubernetes cluster was created successfully  
INFO[2024-12-19T18:29:13-05:00] Waiting for the UI to be ready: ok 
```