### PR TITLE
Initial pass at OLVM doc

### DIFF
--- a/doc/cluster-management/olvm.md
+++ b/doc/cluster-management/olvm.md
@@ -2,10 +2,10 @@
 
 # OLVM Cluster API Provider
 The OLVM Cluster API Provider allows you to create Kubernetes clusters on an
-existing OLVM deployment. The cluster nodes can be spread
+existing OLVM instance. The cluster nodes can be spread
 across multiple OLVM hosts, where both the control plane and worker nodes can
 be scaled in and out as desired. Using the Oracle Cloud Native Environment CLI (`ocne`), 
-you can create and upload the required OLVM compatible OCK image to the OLVM deployment,
+you can create and upload the required OLVM compatible OCK image to the OLVM instance,
 then create the cluster.
 
 ## Terminology
@@ -24,9 +24,22 @@ a cluster is not available, the Oracle Cloud Native Environment CLI will create
 one using the [libvirt](libvirt.md) provider.  It is referred to as a
 "boostrap cluster" or an "ephemeral cluster" depending on the context.
 
-The OLVM Cluster API Provider implements an infrastructure Cluster controller along with
-an infrastructure Machine controller.  Both are housed in a single operator. This
+The OLVM Cluster API Provider implements an infrastructure Cluster controller (OLVMCluster CRD) along with
+an infrastructure Machine controller (OLVMMachine CRD).  Both are housed in a single operator. This
 provider interacts with OLVM using the [oVirt REST API.](https://www.ovirt.org/documentation/doc-REST_API_Guide/)
+
+The oVirt instance is the same as the oVirt installation.  It is where the oVirt console runs, the oVirt engine, etc.
+
+## OLVM vs oVirt
+There is a sutle nuance in the terminology used for OLVM vs oVirt.  The term OLVM really has two meanings
+in this context.  First it reperesents the back-end OLVM instance, which is an oVirt implemenation.  So, the
+term oVirt **always** means the back-end OLVM oVirt instance.  Any resource or entity described as oVirt can
+be viewed from the OLVM management console, or accessed via the oVirt REST API.
+
+There is also the client side, where you create Cluster API resources.  The OLVM Cluster API has an OLVMCluster 
+resource which is not to be confused with either a Kubernetes cluster, or an oVirt cluster. 
+So, when you see OLVM* field names or resource names described in this  document, it is **always** referring to OLVM Cluster API 
+resouces and terminology on the client.
 
 ## Prerequisites
 * You must have an existing OLVM installation that can be accessed via a set of external IPs.
@@ -111,23 +124,152 @@ extraIgnitionInline:
 ```
 
 ## Top-levl OLVM configuration
-The following global configuration specifies:
+The global configuration has 2 sections, global fields and ignition fields.
 
-**networkInterface**
-The interface used by OLVM virtual machines (VMs).
-
-**namespace** 
-The namespace where CLUSTER API resources will be created in your management cluster.
+## Global fields
 ```
+virtualIp: 100.101.70.160 
+provider: olvm
+...
 providers:
   olvm:
     networkInterface: enp1s0
     namespace: olvm-cluster
 ```
+**virtualIp**
+The virtual IP is used as the Kubernetes control plane endpoint (the server field in the kubeconifg file).
+This IP must be external, and cannot be in the range used by the VMs.
+
+**provider**
+The provider must be olvm
+
+**networkInterface**
+The interface used by OLVM virtual machines (VMs).  Currently, the value `enp1s0` is required.
+
+**namespace**
+The namespace where CLUSTER API resources will be created in your management cluster.
+
+## Ignition fields
+The ignition fields need to be updated with your nameserver IP.  The other fields should stay as is. 
+
+```
+extraIgnitionInline:
+  variant: fcos
+  version: 1.5.0
+  storage:
+    files:
+    - path: /etc/resolv.conf
+      mode: 0644
+      overwrite: false
+      contents:
+        inline: |
+          nameserver <name-server-ip>
+```
 
 ## Cluster configuration
+The cluster configuration specifies fields for the OLVMCluster resource.
+
+```
+    olvmCluster:
+      ovirtDatacenterName: Default
+      olvmVmIpProfile:
+        name: default-ip
+        gateway: 1.2.3.1
+        netmask: 255.255.255.0
+        device: enp1s0
+        startingIpAddress: 1.2.3.161
+      ovirtAPI:
+        serverURL: https://ovirt.example.oraclevcn.com/ovirt-engine
+        serverCAPath: "~/olvm/ca.crt"
+      ovirtOCK:
+        storageDomainName: oblock
+        diskName: olvm-ock-1.30
+        diskSize: 16GB
+```
+**ovirtDatacenterName**
+The oVirt datacenter name
+
+### olvmVmIpProfile
+The profile that describes VM IP information.  This profile is an OVLMCluster concept (hence the name)
+
+```
+      olvmVmIpProfile:
+        name: default-ip
+        gateway: 1.2.3.1
+        netmask: 255.255.255.0
+        device: enp1s0
+        startingIpAddress: 1.2.3.161
+```
+**name**
+The profile name. This is referenced by the control plane and machine sections.
+
+**gateway**
+The default gateway on the VM
+
+**netmask**
+The netmask used by the VM
+
+**device**
+The ethernet interface device on the VM
+
+**startingIpAddress**
+The starting IP address to use for VMs.  NOTE: the **virtualIp** cannot be in this range.
+
 
 ## Machine congfiguration
+The control plane and worker fiels are identical, but the values may be different.  These values
+apply to all the control plane nodes and worker nodes in the cluster.
+```
+    controlPlaneMachine:
+      memory: "7GB"
+      network:
+        interfaceType: virtio
+        networkName: vlan
+        vnicName: nic-1
+        vnicProfileName: vlan
+      ovirtClusterName: Default
+      olvmVmIpProfileName: default-ip
+      vmTemplateName: olvm-tmplate-1.30
+      
+    workerMachine:
+      memory: "16GB"
+      network:
+        interfaceType: virtio
+        networkName: vlan
+        vnicName: nic-1
+        vnicProfileName: vlan
+      ovirtClusterName: Default
+      olvmVmIpProfileName: default-ip
+      vmTemplateName: olvm-tmplate-1.30
+
+```
+**memory**
+VM memory allocated for each Kubernetes node.
+
+**network.interfaceType**
+The interface type.  Use virtio unless you need to change it.
+
+**network.Name**
+The oVirt network name.  This must exist in the oVirt instance.
+
+**network.vnicName**
+The oVirt vnicName.  The scope is the VM.
+optional
+
+**network.vnicProfileName**
+The oVirt vnic profile name.  This must exist in the oVirt instance
+
+**ovirtClusterName**
+The oVirt cluster.  This must exist in the datacenter.
+
+**olvmVmIpProfileName**
+The OLVM VM IP profile name that is defined in the cluster section above.
+The VM will use that profile.
+
+**vmTemplateName**
+The oVirt vmTemplate name.  This must exist in the oVirt instance
+(Note: you will need to create a vmTemplate with the OCK image, see instructions later in this document.)
+
 
 # Creating a Cluster
 

--- a/doc/cluster-management/olvm.md
+++ b/doc/cluster-management/olvm.md
@@ -22,7 +22,7 @@ cluster can be its own management cluster.
 Using Cluster API always requires that a Kubernetes cluster is available.  If
 a cluster is not available, the Oracle Cloud Native Environment CLI will create
 one using the [libvirt](libvirt.md) provider.  It is referred to as a
-"boostrap cluster" or an "ephemeral cluster" depending on the context.
+"bootstrap cluster" or an "ephemeral cluster" depending on the context.
 
 The OLVM Cluster API Provider implements an infrastructure Cluster controller (OLVMCluster CRD) along with
 an infrastructure Machine controller (OLVMMachine CRD).  Both are housed in a single operator. This
@@ -33,15 +33,15 @@ Machine and OLVMMachines are CAPI resources. There is an OLVM VM created for eac
 The oVirt instance is the same as the oVirt installation.  It is where the oVirt console runs, the oVirt engine, etc.
 
 ## OLVM vs oVirt
-There is a sutle nuance in the terminology used for OLVM vs oVirt.  The term OLVM really has two meanings
-in this context.  First it reperesents the back-end OLVM instance, which is an oVirt implemenation.  So, the
-term oVirt **always** means the back-end OLVM oVirt instance.  Any resource or entity described as oVirt can
+There is some overlap in the terminology used for OLVM vs oVirt.  The term OLVM really has two meanings
+in this context.  First it represents the backend OLVM oVirt instance, which is an oVirt implementation.  So, the
+term oVirt **always** means the backend OLVM oVirt instance.  Any resource or entity described as oVirt can
 be viewed from the OLVM management console, or accessed via the oVirt REST API.
 
 There is also the client side, where you create Cluster API resources.  The OLVM Cluster API has an OLVMCluster 
 resource which is not to be confused with either a Kubernetes cluster, or an oVirt cluster. 
 So, when you see OLVM* field names or resource names described in this  document, it is **always** referring to OLVM Cluster API 
-resouces and terminology on the client.
+resources and terminology on the client.
 
 ## Prerequisites
 * You must have an existing OLVM installation that can be accessed via a set of external IPs.
@@ -216,8 +216,8 @@ The ethernet interface device on the VM
 The starting IP address to use for VMs.  NOTE: the **virtualIp** cannot be in this range.
 
 
-## Machine congfiguration
-The control plane and worker fiels are identical, but the values may be different.  These values
+## Machine configuration
+The control plane and worker fields are identical, but the values may be different.  These values
 apply to all the control plane nodes and worker nodes in the cluster.
 ```
     controlPlaneMachine:
@@ -274,6 +274,23 @@ The oVirt vmTemplate name.  This must exist in the oVirt instance
 # Preparing to Create a Cluster
 This section describes the steps needed to create a cluster.  Make sure your cluster configuration file
 exists and has the correct values as described in previous sections.
+
+## Credentials 
+Before using the OLVM Cluster API provider, you need to define the following environment variables on
+the machine where you are running `ocne`.
+
+OCNE_OLVM_USERNAME
+OCNE_OLVM_PASSWORD
+OCNE_OLVM_SCOPE
+
+Use "ovirt-app-api" as the scope, unless you have created a user with a different scope.
+The username must have @internal suffix.  So if you log into the OLVM console with "admin", then
+the OCNE_OLVM_USERNAME is "admin@internal"
+
+## oVirt REST API CA Certificate
+You also must download the oVirt REST API CA certificate and put it into a file referenced by the cluster configuration (see below).
+Make sure you only use the second certificate returned by the instructions at [oVirt CA](https://www.ovirt.org/documentation/doc-REST_API_Guide/#obtaining-the-ca-certificate).
+
 
 ## Creating a workload cluster
 First create a workload cluster.  Even though and ephemeral cluster is automatically created, you can 
@@ -345,7 +362,7 @@ Now you need to use the OLVM oVirt console to create a template that uses the im
 3. Fill in the form, only change the following fields:
    Template: Blank
    Operating System: Red Hat Enterprise Linux CoreOS
-   Instance Images > Attach and select the boot.qcow2 disk/image on the list, select the OS (boot) checkbox.  THis is the last checkbox on the right.
+   Instance Images > Attach and select the boot.qcow2 disk/image on the list, select the OS (boot) checkbox, which is the last checkbox on the right.
 
 4. After the VM creation is finished, select but do NOT run it, rather click the "Make Template" menu selection.
 Make sure the template name matches the vmTemplateName in your Oracle Cloud Native Environment CLI cluster configuration.
@@ -516,7 +533,7 @@ You must have available IPs that are reachable from the machine where you are ru
 This includes the virtual IP and all the IPs for the Kubernetes nodes.
 
 ## Capacity
-Make sure your workload cluster has the capacity as specfied in the instructions in the document.  If not, then you will see
+Make sure your workload cluster has the capacity as specified in the instructions in the document.  If not, then you will see
 problems like pods being evicted, etc.
 
 ## Cleanup

--- a/doc/cluster-management/olvm.md
+++ b/doc/cluster-management/olvm.md
@@ -1,7 +1,7 @@
 **NOTE: This is a developer release**
 
 # OLVM Cluster API Provider
-The OLVM Cluster API Provider allows you to create Kubernetes clusters on an
+The Oracle Linux Virtualization Manager (OLVM) Cluster API Provider allows you to create Kubernetes clusters on an
 existing OLVM instance. The cluster nodes can be spread
 across multiple OLVM hosts, where both the control plane and worker nodes can
 be scaled in and out as desired. Using the Oracle Cloud Native Environment CLI (`ocne`), 
@@ -191,7 +191,7 @@ The cluster configuration specifies fields for the OLVMCluster resource.
 The oVirt datacenter name
 
 ### olvmVmIpProfile
-The profile that describes VM IP information.  This profile is an OVLMCluster concept (hence the name)
+The profile that describes VM IP information.  This profile is an OLVMMCluster concept (hence the name)
 ```
       olvmVmIpProfile:
         name: default-ip

--- a/doc/cluster-management/olvm.md
+++ b/doc/cluster-management/olvm.md
@@ -329,7 +329,7 @@ INFO[2024-12-20T13:38:27-05:00] Kubernetes cluster was created successfully
 The first step is to create an OCK image with the default Kubernetes version (1.30 at the time of this writing).
 
 ```
-export KUBECONFIG=/Users/pmackin/.kube/kubeconfig.ocne.local
+export KUBECONFIG=/Users/user/.kube/kubeconfig.ocne.local
 
 ocne image create --type olvm --kubeconfig $KUBECONFIG
 INFO[2024-12-20T13:46:23-05:00] Creating Image                               
@@ -338,18 +338,18 @@ INFO[2024-12-20T13:46:28-05:00] Waiting for pod ocne-system/ocne-image-builder t
 INFO[2024-12-20T13:46:28-05:00] Getting local boot image for architecture: amd64 
 INFO[2024-12-20T13:46:56-05:00] Uploading boot image to pod ocne-system/ocne-image-builder: ok 
 INFO[2024-12-20T13:47:41-05:00] Downloading boot image from pod ocne-system/ocne-image-builder: ok 
-INFO[2024-12-20T13:47:41-05:00] New boot image was created successfully at /Users/pmackin/.ocne/images/boot.qcow2-1.30-amd64.olvm 
+INFO[2024-12-20T13:47:41-05:00] New boot image was created successfully at /Users/user/.ocne/images/boot.qcow2-1.30-amd64.olvm 
 ```
 
 ## Uploading the OLVM OCK image
 Upload the OCK image that you just created to your 
 
 ```
-ocne image upload --type olvm --arch amd64 --file  /Users/pmackin/.ocne/images/boot.qcow2-1.30-amd64.olvm   --config /Users/pmackin/.ocne/olvm-demo-cluster-config.yaml --kubeconfig $KUBECONFIG
-INFO[2024-12-20T13:49:48-05:00] Starting uploaded OCK image `/Users/pmackin/.ocne/images/boot.qcow2-1.30-amd64.olvm` to disk `demo-1-ock-1.30` in storage domain `oblock` 
+ocne image upload --type olvm --arch amd64 --file  /Users/user/.ocne/images/boot.qcow2-1.30-amd64.olvm   --config /Users/user/.ocne/olvm-demo-cluster-config.yaml --kubeconfig $KUBECONFIG
+INFO[2024-12-20T13:49:48-05:00] Starting uploaded OCK image `/Users/user/.ocne/images/boot.qcow2-1.30-amd64.olvm` to disk `demo-1-ock-1.30` in storage domain `oblock` 
 INFO[2024-12-20T13:49:48-05:00] Waiting for disk status to be OK             
 INFO[2024-12-20T13:49:53-05:00] Waiting for image transfer phase transferring 
-INFO[2024-12-20T13:51:56-05:00] Uploading image /Users/pmackin/.ocne/images/boot.qcow2-1.30-amd64.olvm with 2826567680 bytes to demo-1-ock-1.30: ok 
+INFO[2024-12-20T13:51:56-05:00] Uploading image /Users/user/.ocne/images/boot.qcow2-1.30-amd64.olvm with 2826567680 bytes to demo-1-ock-1.30: ok 
 INFO[2024-12-20T13:51:58-05:00] Waiting for image transfer phase finished_success 
 INFO[2024-12-20T13:52:11-05:00] Successfully uploaded OCK image    
 ```
@@ -373,7 +373,7 @@ Now you are ready to create a cluster.  As the cluster is being created, you can
 First the control plane VM (Kubernetes node) is created, followed by the worker VM/
 
 ```
-ocne cluster start --provider olvm  --cluster-name demo --config /Users/pmackin/.ocne/olvm-demo-cluster-config.yaml
+ocne cluster start --provider olvm  --cluster-name demo --config /Users/user/.ocne/olvm-demo-cluster-config.yaml
 INFO[2024-12-20T14:09:31-05:00] Installing cert-manager into cert-manager: ok 
 INFO[2024-12-20T14:09:32-05:00] Installing core-capi into capi-system: ok 
 INFO[2024-12-20T14:09:33-05:00] Installing olvm-capi into cluster-api-provider-olvm: ok 
@@ -394,7 +394,7 @@ INFO[2024-12-20T14:13:46-05:00] Kubernetes cluster was created successfully
 INFO[2024-12-20T14:16:47-05:00] Waiting for the UI to be ready: ok 
 
 Run the following command to create an authentication token to access the UI:
-    KUBECONFIG='/Users/pmackin/.kube/kubeconfig.demo' kubectl create token ui -n ocne-system
+    KUBECONFIG='/Users/user/.kube/kubeconfig.demo' kubectl create token ui -n ocne-system
 Browser window opened, enter 'y' when ready to exit: y
 ```
 

--- a/doc/cluster-management/olvm.md
+++ b/doc/cluster-management/olvm.md
@@ -126,7 +126,7 @@ extraIgnitionInline:
           nameserver 1.2.3.250
 ```
 
-## Top-levl OLVM configuration
+## Global OLVM configuration
 The global configuration has 2 sections, global fields and ignition fields.
 
 ## Global fields

--- a/doc/cluster-management/olvm.md
+++ b/doc/cluster-management/olvm.md
@@ -144,7 +144,7 @@ The virtual IP is used as the Kubernetes control plane endpoint (the server fiel
 This IP must be external, and cannot be in the range used by the VMs.
 
 **provider**
-The provider must be olvm
+The provider must be olvm.
 
 **networkInterface**
 The interface used by OLVM virtual machines (VMs).  Currently, the value `enp1s0` is required.
@@ -191,7 +191,7 @@ The cluster configuration specifies fields for the OLVMCluster resource.
 The oVirt datacenter name
 
 ### olvmVmIpProfile
-The profile that describes VM IP information.  This profile is an OLVMMCluster concept (hence the name)
+The profile that describes VM IP information. This profile is an OLVMMCluster concept (hence the name).
 ```
       olvmVmIpProfile:
         name: default-ip
@@ -204,13 +204,13 @@ The profile that describes VM IP information.  This profile is an OLVMMCluster c
 The profile name. This is referenced by the control plane and machine sections.
 
 **gateway**
-The default gateway on the VM
+The default gateway on the VM.
 
 **netmask**
-The netmask used by the VM
+The netmask used by the VM.
 
 **device**
-The ethernet interface device on the VM
+The ethernet interface device on the VM.
 
 **startingIpAddress**
 The starting IP address to use for VMs.  NOTE: the **virtualIp** cannot be in this range.

--- a/doc/cluster-management/olvm.md
+++ b/doc/cluster-management/olvm.md
@@ -1,0 +1,146 @@
+**NOTE: This is a developer release**
+
+# OLVM Cluster API Provider
+The OLVM Cluster API Provider allows you to create Kubernetes clusters on an
+existing OLVM deployment. The cluster nodes can be spread
+across multiple OLVM hosts, where both the control plane and worker nodes can
+be scaled in and out as desired. Using the Oracle Cloud Native Environment CLI (`ocne`), 
+you can create and upload the required OLVM compatible OCK image to the OLVM deployment,
+then create the cluster.
+
+## Terminology
+Cluster API is an API implemented as Kubernetes custom
+resources (CRDs) that are serviced by applications running in a Kubernetes cluster.
+Cluster API has a large interface.  Please refer to the [community documentation](https://cluster-api.sigs.k8s.io/)
+for a complete description of the configuration options that are available.
+
+The controllers that implement Cluster API run inside a Kubernetes cluster.
+These clusters are known as "management clusters".  Management clusters control
+the lifecycles of other clusters, known as "workload clusters".  A workload
+cluster can be its own management cluster. 
+
+Using Cluster API always requires that a Kubernetes cluster is available.  If
+a cluster is not available, the Oracle Cloud Native Environment CLI will create
+one using the [libvirt](libvirt.md) provider.  It is referred to as a
+"boostrap cluster" or an "ephemeral cluster" depending on the context.
+
+The OLVM Cluster API Provider implements an infrastructure Cluster controller along with
+an infrastructure Machine controller.  Both are housed in a single operator. This
+provider interacts with OLVM using the [oVirt REST API.](https://www.ovirt.org/documentation/doc-REST_API_Guide/)
+
+## Prerequisites
+* You must have an existing OLVM installation that can be accessed via a set of external IPs.
+* You will need an IP for the Kubernetes control plane node and an IP for each cluster node.
+* The CA certificate used for the oVirt rest API must be downloaded to a local file, even if it is not self-signed.  See [oVirt CA](https://www.ovirt.org/documentation/doc-REST_API_Guide/#obtaining-the-ca-certificate)
+
+## Restrictions
+* The OLVM Cluster API Provider does not support DHCP, you must allocate a range of external IPs.
+
+#  Oracle Cloud Native Environment CLI cluster configuration for OLVM
+Before running any `ocne` command related to OLVM, you must create the configuration file.
+The sample below shows a fully functional configuration (with some redacted fields.  This
+configuration introduces a new olvm provider with custom configuration with 4 sections:
+
+* Global OLVM configuration
+* OLVMCluster configuration
+* OLVMMachine configuration for the control plane nodes
+* OLVMMachine configuraiton for the worker nodes
+
+```
+name: demo
+workerNodes: 2
+controlPlaneNodes: 3
+virtualIp: 100.101.70.160 
+password: "$6...1"
+provider: olvm
+providers:
+  olvm:
+    networkInterface: enp1s0
+    namespace: olvm-cluster
+    olvmCluster:
+      ovirtDatacenterName: Default
+      olvmVmIpProfile:
+        name: default-ip
+        gateway: 1.2.3.1
+        netmask: 255.255.255.0
+        device: enp1s0
+        startingIpAddress: 1.2.3.161
+      ovirtAPI:
+        serverURL: https://ovirt.example.oraclevcn.com/ovirt-engine
+        serverCAPath: "~/olvm/ca.crt"
+      ovirtOCK:
+        storageDomainName: oblock
+        diskName: olvm-ock-1.30
+        diskSize: 16GB
+    controlPlaneMachine:
+      memory: "7GB"
+      network:
+        interfaceType: virtio
+        networkName: vlan
+        vnicName: nic-1
+        vnicProfileName: vlan
+      ovirtClusterName: Default
+      olvmVmIpProfileName: default-ip
+      vmTemplateName: olvm-tmplate-1.30
+    workerMachine:
+      memory: "16GB"
+      network:
+        interfaceType: virtio
+        networkName: vlan
+        vnicName: nic-1
+        vnicProfileName: vlan
+      ovirtClusterName: Default
+      olvmVmIpProfileName: default-ip
+      vmTemplateName: olvm-tmplate-1.30
+
+kubernetesVersion: 1.30
+proxy:
+  httpsProxy: http://www-proxy-example.com:80
+  noProxy: .mycorp.com,localhost,127.0.0.1,1.2.3.0/14,nip.io
+extraIgnitionInline:
+  variant: fcos
+  version: 1.5.0
+  storage:
+    files:
+    - path: /etc/resolv.conf
+      mode: 0644
+      overwrite: false
+      contents:
+        inline: |
+          nameserver 1.2.3.250
+```
+
+## Top-levl OLVM configuration
+The following global configuration specifies:
+
+**networkInterface**
+The interface used by OLVM virtual machines (VMs).
+
+**namespace** 
+The namespace where CLUSTER API resources will be created in your management cluster.
+```
+providers:
+  olvm:
+    networkInterface: enp1s0
+    namespace: olvm-cluster
+```
+
+## Cluster configuration
+
+## Machine congfiguration
+
+# Creating a Cluster
+
+## Overview
+
+## Creating the OLVM OCK image
+
+## Uploading the OLVM OCK image
+
+### Creating a VM template
+
+## Starting the cluster
+
+# Creating a Cluster
+
+# Deleting a Cluster


### PR DESCRIPTION
This is the initial pass at OLVM documentation.  This document explains how to create a Kubernetes cluster on an OLVM instance.  This is initially for a developer release.