### PR TITLE
Fix regression when staging cluster with KUBECONFIG

### DIFF
--- a/pkg/commands/cluster/stage/stage.go
+++ b/pkg/commands/cluster/stage/stage.go
@@ -64,7 +64,7 @@ func Stage(o StageOptions) error {
 		return errors.New("the kubernetes version is unsupported. Please choose a supported version of Kubernetes to update to")
 	}
 
-	var doNodes bool
+	doNodes := true
 	var helpStanza string
 
 	// If a cluster config is given, do any provider-specific staging
@@ -84,18 +84,12 @@ func Stage(o StageOptions) error {
 		o.KubeConfigPath = kcfgPath
 	}
 
-	restConfig, err := client.GetKubeConfig(o.KubeConfigPath)
-	if err != nil {
-		return err
-	}
-
 	if !doNodes {
 		fmt.Println(helpStanza)
 		return nil
 	}
 
-	// get a kubernetes client
-	KClient, err := client.GetGoClient(restConfig)
+	restConfig, KClient, err := client.GetKubeClient(o.KubeConfigPath)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This was happening during cluster stage with a KUBECONFIG because I'm a big old dummy and did an incorrect client lookup:
```
[opc@ol9 ocne]$ ./out/linux_amd64/ocne cluster stage --version 1.27 --log-level debug
DEBU[2025-01-15T20:15:10Z] Have cluster config <nil>                    
W0115 20:15:10.715746 3325031 client_config.go:659] Neither --kubeconfig nor --master was specified.  Using the inClusterConfig.  This might not work.
W0115 20:15:10.715761 3325031 client_config.go:664] error creating inClusterConfig, falling back to default config: unable to load in-cluster configuration, KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined
ERRO[2025-01-15T20:15:10Z] invalid configuration: no configuration has been provided, try setting KUBERNETES_MASTER environment variable 
```

After reverting back to the previous implementation, it works:
```
[opc@ol9 ocne]$ ./out/linux_amd64/ocne cluster stage --version 1.27 --log-level debug
DEBU[2025-01-15T20:17:49Z] Have cluster config <nil>                    
DEBU[2025-01-15T20:17:49Z] Sanitizing /home/opc/.kube/kubeconfig.ocne.local 
DEBU[2025-01-15T20:17:49Z] Sanitizing /home/opc/.kube/kubeconfig.ocne.local 
INFO[2025-01-15T20:17:49Z] Running node stage                           
INFO[2025-01-15T20:17:55Z] Waiting for pod ocne-system/stage-node-ocne-control-plane-1-pod to be ready: ok 
INFO[2025-01-15T20:17:55Z] Node ocne-control-plane-1 successfully staged 
```

I staged and updated from 1.26 to 1.30 successfully.