### PR TITLE
Update migration phase1 doc to delete the vmi resource

### DIFF
--- a/doc/experimental/phase1/phase1.md
+++ b/doc/experimental/phase1/phase1.md
@@ -1,6 +1,6 @@
 # Phase One: Verrazzano Migration
 
-### Version: v0.0.19-draft
+### Version: v0.0.20-draft
 
 The instructions must be performed in the sequence outlined in this document.
 

--- a/doc/experimental/phase1/phase1.md
+++ b/doc/experimental/phase1/phase1.md
@@ -238,6 +238,23 @@ kubectl patch vz -n $VZCR_NS $VZCR -p '{"metadata":{"finalizers":[]}}' --type=me
 kubectl delete vz -n $VZCR_NS $VZCR
 ```
 
+## Delete the VerrazzanoMonitoringInstance
+This section describes how to delete the VerrazzanoMonitoringInstance, which is no longer needed.
+This must be done before CRDs are deleted in phase2.
+
+```text
+kubectl delete --all --all-namespaces verrazzanomonitoringinstances --cascade=orphan
+```
+Ensure that it was deleted:
+```
+kubectl get verrazzanomonitoringinstances -A
+```
+output:
+```
+No resources found
+
+```
+
 ## Perform another Cluster Dump
 
 Perform a cluster dump to take snapshot of the cluster state after phase-1 is done.


### PR DESCRIPTION
Update the phase1 doc to delete the VMI with no cascade.  This must be done before deleting the VMO CRD or else the VMI owned resources will be deleted when the VMI is deleted.