### PR TITLE
Update OCI-CCM to 1.30

### DIFF
--- a/doc/cluster-management/upgrade.md
+++ b/doc/cluster-management/upgrade.md
@@ -18,12 +18,44 @@ in sequence.
 ### Staging an Update
 
 The `ocne cluster stage` command is used to stage a cluster upgrade.  The
-command sets various configuration options in the cluster and configures each
-cluster node to upgrade to the next Kubernetes version.
+command does different things depending on the target cluster and the provider.
+For providers implemented with Cluster API, staging an update involves creating
+new boot media, uploading that media, creating new machine templates, and
+suggesting patches that could be applied to Cluster API resources to perform
+the upgrade of the cluster nodes.  For providers that are not implemented with
+Cluster API, staging an update sets various configuraiton options in the cluster
+and configures each cluster node to upgrade to the next Kubernetes minor version.
 
 ```
 $ ocne cluster stage --version 1.30
 ```
+
+### Updating a Cluster Managed By Cluster API
+
+Clusters managed with Cluster API have different update behavior than other
+providers.  Nodes in a Cluster API managed cluster are never updated in place.
+All updates are perfomed by instantiating a new node and removing an existing
+one.  Updates are initiated from the management cluster rather than targetting
+the managed cluster directly.  To stage an update for a Cluster API managed
+cluster, use the kubeconfig for the management cluster and supply either the
+cluster configuration file or the name of the cluster.
+
+Unlike with other providers, staging an update for the same Kubernetes minor
+version is useful.  When staging without a version, a check is performed to
+determine if new boot media is available for the provider for that Kubernetes
+version.  If new media is available, it is uploaded, new templates are created,
+and update instructions are suggested.  That is, it behaves exactly like staging
+an update to the next minor version of Kubernetes.
+
+```
+$ export KUBECONFIG=$(ocne cluster show -C management)
+$ ocne cluster stage --version 1.30  -C managed
+```
+
+Note that there are cases where doing an in-place upgrade of nodes in a Cluster
+API cluster is useful.  Some cluster nodes must be long lived because the host
+resources that are difficult to migrate.  These can be updated in place if
+necessary.
 
 ### Updating a Cluster Node
 
@@ -39,11 +71,13 @@ to the next.
 $ ocne node update --node mynode
 ```
 
-## Example
+## Examples
 
 In this example, a Kubernetes cluster is updated from Kubernetes 1.29 to 1.30.
 
-### Creating a Cluster
+### In-Place Updates
+
+#### Creating a Cluster
 
 Create a small cluster with the libvirt provider.  The same process is used for
 most providers.  The oci provider is an exception because the the Cluster API
@@ -77,7 +111,7 @@ Run the following command to create an authentication token to access the UI:
 
 ```
 
-### Staging the Update
+#### Staging the Update
 
 The cluster is currently running Kubernetes 1.29
 
@@ -136,7 +170,7 @@ Aug 06 16:55:26 ocne111 ocne-update.sh[3804]: Update downloaded.
 Aug 06 16:55:27 ocne111 ocne-update.sh[4377]: node/ocne111 annotated
 ```
 
-### Updating Cluster Nodes
+#### Updating Cluster Nodes
 
 Once an update is available to a node, that node can be updated.  The
 `ocne cluster info` command show whether or not a node can be updated.
@@ -247,7 +281,7 @@ INFO[2024-08-06T17:07:08Z] Running node update
 ...
 ```
 
-### Inspecting the Cluster
+#### Inspecting the Cluster
 
 Once the cluster is complete, the status will report the new version for all the
 cluster nodes.
@@ -280,4 +314,151 @@ Nodes:
   ocne20042	worker		Ready	v1.30.3+1.el8	false
   ocne227	control plane	Ready	v1.30.3+1.el8	false
   ocne3244	control plane	Ready	v1.30.3+1.el8	false
+```
+
+### Upgrading Cluster API Clusters
+
+#### Create a Cluster
+
+Instantiate a small cluster with the oci provider using Kubernetes 1.29.  If a
+management cluster is available, it can be used.  This example uses an ephemeral
+cluster for simplicity.
+
+```
+$ ./out/linux_amd64/ocne cluster start -c mycapi.yaml
+INFO[2025-02-03T22:44:07Z] Installing cert-manager into cert-manager: ok 
+INFO[2025-02-03T22:44:08Z] Installing core-capi into capi-system: ok 
+INFO[2025-02-03T22:44:08Z] Installing capoci into cluster-api-provider-oci-system: ok 
+INFO[2025-02-03T22:44:09Z] Installing bootstrap-capi into capi-kubeadm-bootstrap-system: ok 
+```
+
+#### Stage an Update
+
+Set the kubeconfig to the ephemeral cluster and stage an update to
+Kubernetes 1.30.  A new OCI Custom Image is uploaded with the new Kubernetes
+version.  Next, any existing OCIMachineTemplates that are used by other
+resources are cloned and updated.  Finally, two commands are suggested.  The
+first updates the cluster version and control plane nodes.  The second updates
+the worker nodes.
+
+```
+$ export KUBECONFIG=$(ocne cluster show -C ocne-ephemeral)
+$ ./out/linux_amd64/ocne cluster stage --version 1.30 -c ~/tools/capi-1.29.yaml 
+INFO[2025-02-03T22:52:41Z] Installing cert-manager into cert-manager: ok 
+INFO[2025-02-03T22:52:41Z] Installing core-capi into capi-system: ok 
+INFO[2025-02-03T22:52:42Z] Installing capoci into cluster-api-provider-oci-system: ok 
+INFO[2025-02-03T22:52:42Z] Installing bootstrap-capi into capi-kubeadm-bootstrap-system: ok 
+INFO[2025-02-03T22:52:43Z] Installing control-plane-capi into capi-kubeadm-control-plane-system: ok 
+INFO[2025-02-03T22:52:43Z] Waiting for Core Cluster API Controllers: ok 
+INFO[2025-02-03T22:52:43Z] Waiting for Kubadm Boostrap Cluster API Controllers: ok 
+INFO[2025-02-03T22:52:43Z] Waiting for Kubadm Control Plane Cluster API Controllers: ok 
+INFO[2025-02-03T22:52:43Z] Waiting for OCI Cluster API Controllers: ok 
+INFO[2025-02-03T22:52:44Z] Preparing pod used to create image           
+INFO[2025-02-03T22:52:49Z] Waiting for pod ocne-system/ocne-image-builder to be ready: ok 
+INFO[2025-02-03T22:52:49Z] Getting local boot image for architecture: amd64 
+INFO[2025-02-03T22:53:25Z] Uploading boot image to pod ocne-system/ocne-image-builder: ok 
+INFO[2025-02-03T22:54:45Z] Downloading boot image from pod ocne-system/ocne-image-builder: ok 
+INFO[2025-02-03T22:54:45Z] New boot image was created successfully at /home/opc/.ocne/images/boot.qcow2-1.30-amd64.oci 
+INFO[2025-02-03T22:55:08Z] Uploading image to object storage: ok 
+INFO[2025-02-03T23:10:10Z] Importing updated image for ock: [##########]: ok 
+INFO[2025-02-03T23:10:11Z] Running node stage                           
+INFO[2025-02-03T23:10:16Z] Waiting for pod ocne-system/stage-node-ocne-control-plane-9xqmv-pod to be ready: ok 
+INFO[2025-02-03T23:10:16Z] Node ocne-control-plane-9xqmv successfully staged 
+INFO[2025-02-03T23:10:16Z] Running node stage                           
+INFO[2025-02-03T23:10:22Z] Waiting for pod ocne-system/stage-node-ocne-md-0-jt8hb-sswfq-pod to be ready: ok 
+INFO[2025-02-03T23:10:22Z] Node ocne-md-0-jt8hb-sswfq successfully staged 
+INFO[2025-02-03T23:10:22Z] Running node stage                           
+INFO[2025-02-03T23:10:28Z] Waiting for pod ocne-system/stage-node-ocne-md-0-jt8hb-vhndn-pod to be ready: ok 
+INFO[2025-02-03T23:10:28Z] Node ocne-md-0-jt8hb-vhndn successfully staged 
+To update KubeadmControlPlane ocne-control-plane in ocne, run:
+    kubectl patch -n ocne kubeadmcontrolplane ocne-control-plane --type=json -p='[{"op":"replace","path":"/spec/version","value":"1.30.3"},{"op":"replace","path":"/spec/machineTemplate/infrastructureRef/name","value":"ocne-control-plane-1"},{"op":"add","path":"/spec/kubeadmConfigSpec/joinConfiguration/patches","value":{"directory":"/etc/ocne/ock/patches"}}]'
+
+To update MachineDeployment ocne-md-0 in ocne, run:
+    kubectl patch -n ocne machinedeployment ocne-md-0 --type=json -p='[{"op":"replace","path":"/spec/template/spec/version","value":"1.30.3"},{"op":"replace","path":"/spec/template/spec/infrastructureRef/name","value":"ocne-md-1"}]'
+```
+
+#### Update the Control Plane
+
+Executing the first suggested command from the previous step will update the
+control plane.  The cluster version is updated and then a new set of control
+plane nodes are instantiated using that version.  It can take several minutes
+to update the control plane based on how many control plane nodes are in the
+cluster.
+
+```
+$ kubectl patch -n ocne kubeadmcontrolplane ocne-control-plane --type=json -p='[{"op":"replace","path":"/spec/version","value":"1.30.3"},{"op":"replace","path":"/spec/machineTemplate/infrastructureRef/name","value":"ocne-control-plane-1"},{"op":"add","path":"/spec/kubeadmConfigSpec/joinConfiguration/patches","value":{"directory":"/etc/ocne/ock/patches"}}]'
+kubeadmcontrolplane.controlplane.cluster.x-k8s.io/ocne-control-plane patched
+```
+
+#### Wait for the Update to Complete
+
+The control plane update will take some amount of time.  It is possible to
+watch the progress of the update by inspecting the Cluster API resources.
+
+```
+# A new node is being created.  Notice the version.
+$ kubectl -n ocne get machine
+NAME                       CLUSTER   NODENAME                   PROVIDERID                                                                                  PHASE          AGE   VERSION
+ocne-control-plane-9xqmv   ocne      ocne-control-plane-9xqmv   oci://ocid1.instance.oc1.iad.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa   Running        29m   v1.29.3
+ocne-control-plane-p55sl   ocne                                                                                                                             Provisioning   23s   v1.30.3
+ocne-md-0-jt8hb-sswfq      ocne      ocne-md-0-jt8hb-sswfq      oci://ocid1.instance.oc1.iad.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa   Running        29m   v1.29.3
+ocne-md-0-jt8hb-vhndn      ocne      ocne-md-0-jt8hb-vhndn      oci://ocid1.instance.oc1.iad.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa   Running        29m   v1.29.3
+
+# The previous node has been deleted
+$ kubectl -n ocne get machine
+NAME                       CLUSTER   NODENAME                   PROVIDERID                                                                                  PHASE     AGE    VERSION
+ocne-control-plane-p55sl   ocne      ocne-control-plane-p55sl   oci://ocid1.instance.oc1.iad.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa   Running   5m3s   v1.30.3
+ocne-md-0-jt8hb-sswfq      ocne      ocne-md-0-jt8hb-sswfq      oci://ocid1.instance.oc1.iad.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa   Running   34m    v1.29.3
+ocne-md-0-jt8hb-vhndn      ocne      ocne-md-0-jt8hb-vhndn      oci://ocid1.instance.oc1.iad.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa   Running   34m    v1.29.3
+
+# The cluster nodes report the same information
+$ export KUBECONFIG=$(ocne cluster show -C capi)
+$ kubectl get node
+NAME                       STATUS   ROLES           AGE     VERSION
+ocne-control-plane-p55sl   Ready    control-plane   4m30s   v1.30.3+2.el8
+ocne-md-0-jt8hb-sswfq      Ready    <none>          31m     v1.29.3+3.el8
+ocne-md-0-jt8hb-vhndn      Ready    <none>          30m     v1.29.3+3.el8
+```
+
+#### Update the Worker Nodes
+
+Once all control plane nodes are updated, it is possible to update the worker
+nodes.  The overall behavior of updating worker nodes is identitical to the
+control plane nodes.
+
+```
+$ export KUBECONFIG=$(ocne cluster show -C ocne-ephemeral)
+$ kubectl patch -n ocne machinedeployment ocne-md-0 --type=json -p='[{"op":"replace","path":"/spec/template/spec/version","value":"1.30.3"},{"op":"replace","path":"/spec/template/spec/infrastructureRef/name","value":"ocne-md-1"}]'
+machinedeployment.cluster.x-k8s.io/ocne-md-0 patched
+```
+
+#### Watch the Worker Node Update Progress
+
+The worker node update can take a while, especially if there are a lot of
+nodes.  The time it takes to update nodes depends on many factors, such as
+cluster size, workloads, and more.
+
+```
+# A new node is rolling out
+$ kubectl -n ocne get machine
+NAME                       CLUSTER   NODENAME                   PROVIDERID                                                                                  PHASE         AGE     VERSION
+ocne-control-plane-p55sl   ocne      ocne-control-plane-p55sl   oci://ocid1.instance.oc1.iad.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa   Running       8m50s   v1.30.3
+ocne-md-0-9xzrv-dphhk      ocne      ocne-md-0-9xzrv-dphhk      oci://ocid1.instance.oc1.iad.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa   Running       2m51s   v1.30.3
+ocne-md-0-9xzrv-qsbbj      ocne                                 oci://ocid1.instance.oc1.iad.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa   Provisioned   40s     v1.30.3
+ocne-md-0-jt8hb-vhndn      ocne      ocne-md-0-jt8hb-vhndn      oci://ocid1.instance.oc1.iad.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa   Running       38m     v1.29.3
+
+# The nodes have been updated
+$ kubectl -n ocne get machine
+NAME                       CLUSTER   NODENAME                   PROVIDERID                                                                                  PHASE     AGE     VERSION
+ocne-control-plane-p55sl   ocne      ocne-control-plane-p55sl   oci://ocid1.instance.oc1.iad.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa   Running   11m     v1.30.3
+ocne-md-0-9xzrv-dphhk      ocne      ocne-md-0-9xzrv-dphhk      oci://ocid1.instance.oc1.iad.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa   Running   5m27s   v1.30.3
+ocne-md-0-9xzrv-qsbbj      ocne      ocne-md-0-9xzrv-qsbbj      oci://ocid1.instance.oc1.iad.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa   Running   3m16s   v1.30.3
+
+# The managed cluster shows the same information
+$ export KUBECONFIG=$(ocne cluster show -C capi)
+$ kubectl get node
+NAME                       STATUS   ROLES           AGE     VERSION
+ocne-control-plane-p55sl   Ready    control-plane   10m     v1.30.3+2.el8
+ocne-md-0-9xzrv-dphhk      Ready    <none>          4m43s   v1.30.3+2.el8
+ocne-md-0-9xzrv-qsbbj      Ready    <none>          2m43s   v1.30.3+2.el8
 ```

--- a/pkg/cluster/driver/capi/capi.go
+++ b/pkg/cluster/driver/capi/capi.go
@@ -46,7 +46,7 @@ const (
 	OciCcmChart         = "oci-ccm"
 	OciCcmNamespace     = "kube-system"
 	OciCcmRelease       = "oci-ccm"
-	OciCcmVersion       = "1.28.0"
+	OciCcmVersion       = "1.30.0"
 	OciCcmSecretName    = "oci-cloud-controller-manager"
 	OciCcmCsiSecretName = "oci-volume-provisioner"
 


### PR DESCRIPTION
```
# Cluster
[opc@ol9 ocne]$ export KUBECONFIG=$(ocne cluster show -C capi)
[opc@ol9 ocne]$ ocne application ls -A
Releases
NAME        	NAMESPACE   	CHART       	STATUS  	REVISION	APPVERSION
core-dns    	kube-system 	coredns     	deployed	1       	2.0.0     
flannel     	kube-flannel	flannel     	deployed	1       	0.22.3    
kube-proxy  	kube-system 	kube-proxy  	deployed	1       	2.0.0     
oci-ccm     	kube-system 	oci-ccm     	deployed	1       	1.30.0    
ocne-catalog	ocne-system 	ocne-catalog	deployed	1       	2.0.0     
ui          	ocne-system 	ui          	deployed	1       	2.0.0     

# Pod with PVC
[opc@ol9 ocne]$ cat ~/tools/pvcpod.yaml 
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: my-pvc
spec:
  accessModes:
    - ReadWriteOnce
  resources:
    requests:
      storage: 5Gi
---
apiVersion: v1
kind: Pod
metadata:
  name: my-pod
spec:
  volumes:
    - name: my-storage
      persistentVolumeClaim:
        claimName: my-pvc
  containers:
    - name: my-container
      command: ["sleep", "10d"]
      image: container-registry.oracle.com/os/oraclelinux:8
      volumeMounts:
        - mountPath: "/volume"
          name: my-storage

[opc@ol9 ocne]$ kubectl get pod
NAME     READY   STATUS    RESTARTS   AGE
my-pod   1/1     Running   0          2m20s
[opc@ol9 ocne]$ kubectl get pv
NAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM            STORAGECLASS   VOLUMEATTRIBUTESCLASS   REASON   AGE
csi-65cd4a98-9fbd-4222-aaf0-0e6435e86295   50Gi       RWO            Delete           Bound    default/my-pvc   oci-bv         <unset>                          2m18s
[opc@ol9 ocne]$ kubectl get pvc
NAME     STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   VOLUMEATTRIBUTESCLASS   AGE
my-pvc   Bound    csi-65cd4a98-9fbd-4222-aaf0-0e6435e86295   50Gi       RWO            oci-bv         <unset>                 2m31s


# Load Balancer
[opc@ol9 ocne]$ kubectl -n ocne-system get svc ui -o yaml
apiVersion: v1
kind: Service
metadata:
  annotations:
    meta.helm.sh/release-name: ui
    meta.helm.sh/release-namespace: ocne-system
    service.beta.kubernetes.io/oci-load-balancer-internal: "true"
  creationTimestamp: "2025-02-05T19:44:29Z"
  finalizers:
  - service.kubernetes.io/load-balancer-cleanup
  labels:
    app.kubernetes.io/instance: ui
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: ui
    app.kubernetes.io/version: 2.0.0
    helm.sh/chart: ui-2.0.0
  name: ui
  namespace: ocne-system
  resourceVersion: "1755"
  uid: b0028404-3abb-462f-8743-7274cdc6a1f1
spec:
  allocateLoadBalancerNodePorts: true
  clusterIP: 10.107.23.223
  clusterIPs:
  - 10.107.23.223
  externalTrafficPolicy: Cluster
  internalTrafficPolicy: Cluster
  ipFamilies:
  - IPv4
  ipFamilyPolicy: SingleStack
  ports:
  - name: https
    nodePort: 31588
    port: 443
    protocol: TCP
    targetPort: https
  selector:
    app.kubernetes.io/instance: ui
    app.kubernetes.io/name: ui
  sessionAffinity: None
  type: LoadBalancer
status:
  loadBalancer:
    ingress:
    - ip: 1.2.3.4
      ipMode: VIP

# "You need to enable JavaScript" is the expected response from the UI root via curl.
[opc@ol9 ocne]$ curl -k https://1.2.3.4:443
<!doctype html><html lang="en"><head><meta charset="utf-8"/><link rel="icon" href="/favicon.ico"/><meta name="viewport" content="width=device-width,initial-scale=1"/><meta name="theme-color" content="#000000"/><link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png"><link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png"><link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png"><link rel="mask-icon" href="/safari-pinned-tab.svg" color="#5bbad5"><meta name="msapplication-TileColor" content="#fff"><meta name="description" content="Headlamp: Kubernetes Web UI"/><style>@font-face{font-family:Overpass;font-style:normal;font-weight:400;font-display:swap;src:url(/fonts/overpass/cyrillic-ext.woff2) format('woff2');unicode-range:U+0460-052F,U+1C80-1C88,U+20B4,U+2DE0-2DFF,U+A640-A69F,U+FE2E-FE2F}@font-face{font-family:Overpass;font-style:normal;font-weight:400;font-display:swap;src:url(/fonts/overpass/cyrillic.woff2) format('woff2');unicode-range:U+0301,U+0400-045F,U+0490-0491,U+04B0-04B1,U+2116}@font-face{font-family:Overpass;font-style:normal;font-weight:400;font-display:swap;src:url(/fonts/overpass/vietnamese.woff2) format('woff2');unicode-range:U+0102-0103,U+0110-0111,U+0128-0129,U+0168-0169,U+01A0-01A1,U+01AF-01B0,U+1EA0-1EF9,U+20AB}@font-face{font-family:Overpass;font-style:normal;font-weight:400;font-display:swap;src:url(/fonts/overpass/latin-ext.woff2) format('woff2');unicode-range:U+0100-024F,U+0259,U+1E00-1EFF,U+2020,U+20A0-20AB,U+20AD-20CF,U+2113,U+2C60-2C7F,U+A720-A7FF}@font-face{font-family:Overpass;font-style:normal;font-weight:400;font-display:swap;src:url(/fonts/overpass/latin.woff2) format('woff2');unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+2000-206F,U+2074,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD}</style><link rel="apple-touch-icon" href="logo192.png"/><link rel="manifest" href="/manifest.json"/><title>Headlamp</title><script>headlampBaseUrl="/"</script><script defer="defer" src="/static/js/main.e29963da.js"></script><link href="/static/css/main.fa4908cd.css" rel="stylesheet"></head><body><noscript>You need to enable JavaScript to run this app.</noscript><div id="root"></div></body></html>
```