### PR TITLE
Add kubernetes 1.31

### DIFF
--- a/pkg/catalog/versions/k8s.go
+++ b/pkg/catalog/versions/k8s.go
@@ -50,6 +50,12 @@ var kubernetesVersions = map[string]KubernetesVersions{
 		Etcd:       "3.5.12",
 		CoreDNS:    "current",
 	},
+	"1.31.0": {
+		Kubernetes: "1.31.0",
+		Pause: "3.10",
+		Etcd: "3.5.15",
+		CoreDNS: "current",
+	},
 }
 
 func init() {
@@ -59,6 +65,7 @@ func init() {
 	kubernetesVersions["1.28"] = kubernetesVersions["1.28.8"]
 	kubernetesVersions["1.29"] = kubernetesVersions["1.29.3"]
 	kubernetesVersions["1.30"] = kubernetesVersions["1.30.3"]
+	kubernetesVersions["1.31"] = kubernetesVersions["1.31.0"]
 }
 
 func GetKubernetesVersions(ver string) (KubernetesVersions, error) {

--- a/pkg/cluster/ignition/kubeadm.go
+++ b/pkg/cluster/ignition/kubeadm.go
@@ -135,7 +135,8 @@ type JoinConfig struct {
 	ControlPlane     ControlPlane     `yaml:"controlPlane,omitempty"`
 	NodeRegistration NodeRegistration `yaml:"nodeRegistration,omitempty"`
 	Discovery        Discovery        `yaml:"discovery,omitempty"`
-	Patches          *Patches          `yaml:"patches,omitempty"`
+	Patches          *Patches         `yaml:"patches,omitempty"`
+	SkipPhases       []string         `yaml:"skipPhases,omitempty"`
 }
 
 type ControlPlane struct {
@@ -230,6 +231,9 @@ func GenerateKubeadmJoin(cj *ClusterJoin) *JoinConfig {
 				Token:             cj.JoinToken,
 				CACertHashes:      cj.KubePKICertHashes,
 			},
+		},
+		SkipPhases: []string{
+			"preflight",
 		},
 		Patches: &Patches{
 			Directory: update.OckPatchDirectory,

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -44,7 +44,7 @@ const (
 	CertKey = "tls.crt"
 	PrivKey = "tls.key"
 
-	KubeVersion = "1.30"
+	KubeVersion = "1.31"
 
 	OciControlPlaneOcpus = 2
 	OciWorkerOcpus       = 4


### PR DESCRIPTION
Adds support for Kubernetes 1.31

Flannel Test
```
[opc@ol9 ocne]$ ./out/linux_amd64/ocne cluster start --control-plane-nodes 3 --worker-nodes 3
INFO[2025-02-06T01:48:43Z] Creating new Kubernetes cluster with version 1.31 named ocne 

INFO[2025-02-06T01:49:37Z] Waiting for the Kubernetes cluster to be ready: ok 





INFO[2025-02-06T01:49:42Z] Installing core-dns into kube-system: ok 
INFO[2025-02-06T01:49:43Z] Installing kube-proxy into kube-system: ok 
INFO[2025-02-06T01:49:44Z] Installing flannel into kube-flannel: ok 
INFO[2025-02-06T01:49:46Z] Installing ui into ocne-system: ok 
INFO[2025-02-06T01:49:47Z] Installing ocne-catalog into ocne-system: ok 
INFO[2025-02-06T01:49:47Z] Kubernetes cluster was created successfully  
INFO[2025-02-06T01:51:17Z] Waiting for the UI to be ready: ok 

Run the following command to create an authentication token to access the UI:
    KUBECONFIG='/home/opc/.kube/kubeconfig.ocne.local' kubectl create token ui -n ocne-system
Browser window opened, enter 'y' when ready to exit: y

INFO[2025-02-06T01:51:19Z] Post install information:

To access the cluster from the VM host:
    copy /home/opc/.kube/kubeconfig.ocne.vm to that host and run kubectl there
To access the cluster from this system:
    use /home/opc/.kube/kubeconfig.ocne.local
To access the UI, first do kubectl port-forward to allow the browser to access the UI.
Run the following command, then access the UI from the browser using via https://localhost:8443
    kubectl port-forward -n ocne-system service/ui 8443:443
Run the following command to create an authentication token to access the UI:
    kubectl create token ui -n ocne-system 
[opc@ol9 ocne]$ kubectl get nodes
NAME                   STATUS   ROLES           AGE    VERSION
ocne-control-plane-1   Ready    control-plane   109s   v1.31.5+1.el8
ocne-control-plane-2   Ready    control-plane   58s    v1.31.5+1.el8
ocne-control-plane-3   Ready    control-plane   59s    v1.31.5+1.el8
ocne-worker-1          Ready    <none>          60s    v1.31.5+1.el8
ocne-worker-2          Ready    <none>          60s    v1.31.5+1.el8
ocne-worker-3          Ready    <none>          59s    v1.31.5+1.el8
[opc@ol9 ocne]$ kubectl get pods -A
NAMESPACE      NAME                                           READY   STATUS    RESTARTS      AGE
kube-flannel   kube-flannel-ds-85d4h                          1/1     Running   1 (31s ago)   66s
kube-flannel   kube-flannel-ds-bsjm6                          1/1     Running   1 (32s ago)   67s
kube-flannel   kube-flannel-ds-fl5dt                          1/1     Running   1 (31s ago)   67s
kube-flannel   kube-flannel-ds-gqch4                          1/1     Running   1 (30s ago)   65s
kube-flannel   kube-flannel-ds-mzls2                          1/1     Running   1 (28s ago)   66s
kube-flannel   kube-flannel-ds-xm5l8                          1/1     Running   1 (71s ago)   105s
kube-system    coredns-7dcb9db977-99dkk                       0/1     Running   0             107s
kube-system    coredns-7dcb9db977-jg8x9                       0/1     Running   0             107s
kube-system    etcd-ocne-control-plane-1                      1/1     Running   0             115s
kube-system    etcd-ocne-control-plane-2                      1/1     Running   0             52s
kube-system    etcd-ocne-control-plane-3                      1/1     Running   0             66s
kube-system    kube-apiserver-ocne-control-plane-1            1/1     Running   0             115s
kube-system    kube-apiserver-ocne-control-plane-2            1/1     Running   0             62s
kube-system    kube-apiserver-ocne-control-plane-3            1/1     Running   0             66s
kube-system    kube-controller-manager-ocne-control-plane-1   1/1     Running   0             115s
kube-system    kube-controller-manager-ocne-control-plane-2   1/1     Running   0             62s
kube-system    kube-controller-manager-ocne-control-plane-3   1/1     Running   0             66s
kube-system    kube-proxy-454pd                               1/1     Running   0             66s
kube-system    kube-proxy-n6dh5                               1/1     Running   0             65s
kube-system    kube-proxy-p9x7s                               1/1     Running   0             67s
kube-system    kube-proxy-qrp8r                               1/1     Running   0             66s
kube-system    kube-proxy-t79w9                               1/1     Running   0             67s
kube-system    kube-proxy-vk88x                               1/1     Running   0             106s
kube-system    kube-scheduler-ocne-control-plane-1            1/1     Running   0             115s
kube-system    kube-scheduler-ocne-control-plane-2            1/1     Running   0             62s
kube-system    kube-scheduler-ocne-control-plane-3            1/1     Running   0             66s
ocne-system    ocne-catalog-8c94cc49f-48r7f                   1/1     Running   0             102s
ocne-system    ui-6bd5787bb4-fgtxb                            1/1     Running   0             103s

[opc@ol9 cluster]$ ./basic_k8s_test.sh > ~/tmp/1.31_flannel_basic.out 2>&1
[opc@ol9 cluster]$ 
[opc@ol9 cluster]$ tail ~/tmp/1.31_flannel_basic.out 
pod/nginx-7cbcd794fd-7rczz condition met
+ break
+ [[ 0 -eq 1 ]]
+ logInfo 'Successfully ran k8s tests! :)'
++ isFuncDeclared log
++ declare -Ff log
++ echo 1
+ '[' 1 -eq 0 ']'
+ echo Successfully ran k8s 'tests!' ':)'
Successfully ran k8s tests! :)
```

Calico Test
```
[opc@ol9 ocne]$ ./out/linux_amd64/ocne cluster start -c ~/tools/calico-ebpf.yaml --control-plane-nodes 3 --worker-nodes 3
INFO[2025-02-06T02:13:16Z] Creating new Kubernetes cluster with version 1.31 named ocne 

INFO[2025-02-06T02:14:00Z] Waiting for the Kubernetes cluster to be ready: ok 





INFO[2025-02-06T02:14:06Z] Installing core-dns into kube-system: ok 
INFO[2025-02-06T02:14:07Z] Installing kube-proxy into kube-system: ok 
INFO[2025-02-06T02:14:09Z] Installing ui into ocne-system: ok 
INFO[2025-02-06T02:14:10Z] Installing ocne-catalog into ocne-system: ok 
INFO[2025-02-06T02:14:15Z] Installing tigera-operator into tigera-system: ok 
INFO[2025-02-06T02:14:15Z] Kubernetes cluster was created successfully  
INFO[2025-02-06T02:14:15Z] Post install information:

To access the cluster from the VM host:
    copy /home/opc/.kube/kubeconfig.ocne.vm to that host and run kubectl there
To access the cluster from this system:
    use /home/opc/.kube/kubeconfig.ocne.local
To access the UI, first do kubectl port-forward to allow the browser to access the UI.
Run the following command, then access the UI from the browser using via https://localhost:8443
    kubectl port-forward -n ocne-system service/ui 8443:443
Run the following command to create an authentication token to access the UI:
    kubectl create token ui -n ocne-system

[opc@ol9 ocne]$ kubectl get node
NAME                   STATUS   ROLES           AGE     VERSION
ocne-control-plane-1   Ready    control-plane   3m54s   v1.31.5+1.el8
ocne-control-plane-2   Ready    control-plane   3m3s    v1.31.5+1.el8
ocne-control-plane-3   Ready    control-plane   3m4s    v1.31.5+1.el8
ocne-worker-1          Ready    <none>          3m5s    v1.31.5+1.el8
ocne-worker-2          Ready    <none>          3m5s    v1.31.5+1.el8
ocne-worker-3          Ready    <none>          3m6s    v1.31.5+1.el8
[opc@ol9 ocne]$ kubectl get pods -A
NAMESPACE       NAME                                           READY   STATUS    RESTARTS        AGE
calico-system   calico-kube-controllers-68464958d-lsxwg        1/1     Running   0               3m32s
calico-system   calico-node-5zqq6                              1/1     Running   0               3m8s
calico-system   calico-node-84lfs                              0/1     Running   0               3m6s
calico-system   calico-node-8bq2w                              1/1     Running   0               3m9s
calico-system   calico-node-fmktp                              1/1     Running   0               3m32s
calico-system   calico-node-pf4fr                              1/1     Running   0               3m7s
calico-system   calico-node-qxv5h                              1/1     Running   0               3m8s
calico-system   calico-typha-556496b9d7-2g7qn                  1/1     Running   0               3m32s
calico-system   calico-typha-556496b9d7-75fb6                  1/1     Running   0               3m3s
calico-system   calico-typha-556496b9d7-bdmrg                  1/1     Running   0               3m3s
calico-system   csi-node-driver-47ssw                          2/2     Running   0               3m8s
calico-system   csi-node-driver-4krvk                          2/2     Running   0               3m9s
calico-system   csi-node-driver-69q2t                          2/2     Running   0               3m8s
calico-system   csi-node-driver-7mc7h                          2/2     Running   0               3m6s
calico-system   csi-node-driver-8jwdn                          2/2     Running   0               3m7s
calico-system   csi-node-driver-kjcc7                          2/2     Running   0               3m32s
kube-system     coredns-7dcb9db977-75szk                       1/1     Running   0               3m48s
kube-system     coredns-7dcb9db977-dr4r2                       1/1     Running   0               3m48s
kube-system     etcd-ocne-control-plane-1                      1/1     Running   0               3m54s
kube-system     etcd-ocne-control-plane-2                      1/1     Running   0               2m55s
kube-system     etcd-ocne-control-plane-3                      1/1     Running   0               3m7s
kube-system     kube-apiserver-ocne-control-plane-1            1/1     Running   0               3m54s
kube-system     kube-apiserver-ocne-control-plane-2            1/1     Running   1 (2m34s ago)   3m3s
kube-system     kube-apiserver-ocne-control-plane-3            1/1     Running   0               3m7s
kube-system     kube-controller-manager-ocne-control-plane-1   1/1     Running   0               3m54s
kube-system     kube-controller-manager-ocne-control-plane-2   1/1     Running   0               3m3s
kube-system     kube-controller-manager-ocne-control-plane-3   1/1     Running   0               3m7s
kube-system     kube-proxy-gg698                               1/1     Running   0               3m6s
kube-system     kube-proxy-pr6nr                               1/1     Running   0               3m7s
kube-system     kube-proxy-rr4gr                               1/1     Running   0               3m47s
kube-system     kube-proxy-spntc                               1/1     Running   0               3m8s
kube-system     kube-proxy-t2m8t                               1/1     Running   0               3m9s
kube-system     kube-proxy-w8sqz                               1/1     Running   0               3m8s
kube-system     kube-scheduler-ocne-control-plane-1            1/1     Running   0               3m54s
kube-system     kube-scheduler-ocne-control-plane-2            1/1     Running   0               3m3s
kube-system     kube-scheduler-ocne-control-plane-3            1/1     Running   0               3m4s
ocne-system     ocne-catalog-8c94cc49f-khp85                   1/1     Running   0               3m45s
ocne-system     ui-6bd5787bb4-gvkkv                            1/1     Running   0               3m46s
tigera-system   tigera-operator-75b8ccf5fd-thwbj               1/1     Running   0               3m40s

[opc@ol9 cluster]$ ./basic_k8s_test.sh > ~/tmp/1.31_calico_basic.out 2>&1
[opc@ol9 cluster]$ tail ~/tmp/1.31_calico_basic.out 
pod/nginx-7cbcd794fd-2c79j condition met
+ break
+ [[ 0 -eq 1 ]]
+ logInfo 'Successfully ran k8s tests! :)'
++ isFuncDeclared log
++ declare -Ff log
++ echo 1
+ '[' 1 -eq 0 ']'
+ echo Successfully ran k8s 'tests!' ':)'
Successfully ran k8s tests! :)
```