### PR TITLE
254-500-error-when-mirror-the-catalog

### DIFF
--- a/pkg/commands/catalog/copy/copy.go
+++ b/pkg/commands/catalog/copy/copy.go
@@ -7,10 +7,10 @@ import (
 	"bufio"
 	"fmt"
 	"github.com/containers/image/v5/copy"
+	log "github.com/sirupsen/logrus"
 	"github.com/oracle-cne/ocne/pkg/catalog"
 	"github.com/oracle-cne/ocne/pkg/image"
 	"github.com/oracle-cne/ocne/pkg/util"
-	log "github.com/sirupsen/logrus"
 	"os"
 	"strings"
 )


### PR DESCRIPTION
Added logic to retry image copying if a 500 error is encountered with a delay between each retry. 