### PR TITLE
2.1.0 RC1

### DIFF
--- a/buildrpm/ocne.spec
+++ b/buildrpm/ocne.spec
@@ -5,8 +5,8 @@
 %global _buildhost build-ol%{?oraclelinux}-%{?_arch}.oracle.com
 
 Name: ocne
-Version: 2.0.5
-Release: 5%{dist}
+Version: 2.1.0
+Release: 1%{dist}
 Vendor: Oracle America
 Summary: Oracle Cloud Native Environment command line interface
 License: UPL 1.0
@@ -71,6 +71,11 @@ chmod 755 %{buildroot}%{_sysconfdir}/bash_completion.d/ocne
 %{_sysconfdir}/bash_completion.d/ocne
 
 %changelog
+* Wed Feb 12 2024 Daniel Krasinski <daniel.krasinski@oracle.com> - 2.1.0-1
+- Introduce support for Kubernetes 1.31
+- Fix an issue where in-place updates in environments without internet access can disrupt cluster function
+- Add support for staging Cluster API resources with the oci provider
+
 * Tue Nov 19 2024 George Aeillo <george.f.aeillo@oracle.com> - 2.0.5-5
 - Allow YAML output from cluster dumps
 - Fix various issues in cluster dump and info commands

--- a/buildrpm/ocne.spec
+++ b/buildrpm/ocne.spec
@@ -71,7 +71,7 @@ chmod 755 %{buildroot}%{_sysconfdir}/bash_completion.d/ocne
 %{_sysconfdir}/bash_completion.d/ocne
 
 %changelog
-* Wed Feb 12 2024 Daniel Krasinski <daniel.krasinski@oracle.com> - 2.1.0-1
+* Wed Feb 12 2025 Daniel Krasinski <daniel.krasinski@oracle.com> - 2.1.0-1
 - Introduce support for Kubernetes 1.31
 - Fix an issue where in-place updates in environments without internet access can disrupt cluster function
 - Add support for staging Cluster API resources with the oci provider

--- a/pkg/cluster/driver/capi/capi.go
+++ b/pkg/cluster/driver/capi/capi.go
@@ -591,7 +591,7 @@ func (cad *ClusterApiDriver) ensureImage(name string, arch string, version strin
 
 	// Check for a local image.  First see if there is already an image
 	// available in OCI
-	_, found, err := oci.GetImage(constants.OciImageName, cad.ClusterConfig.KubeVersion, arch, compartmentId)
+	_, found, err := oci.GetImage(constants.OciImageName, version, arch, compartmentId)
 	if found && !force {
 		// An image was found.  Perfect.
 		return "", "", nil
@@ -614,7 +614,9 @@ func (cad *ClusterApiDriver) ensureImage(name string, arch string, version strin
 	// No image exists.  Make one.  Save the existing KC value and substitute
 	// the ephemeral one.  Set it back when done.
 	oldKcfg := cad.Config.KubeConfig
+	oldKver := cad.ClusterConfig.KubeVersion
 	cad.Config.KubeConfig = cad.BootstrapKubeConfig
+	cad.ClusterConfig.KubeVersion = version
 	if cad.ClusterConfig.OsTag == "" {
 		cad.ClusterConfig.OsTag = version
 	}
@@ -623,6 +625,7 @@ func (cad *ClusterApiDriver) ensureImage(name string, arch string, version strin
 		Architecture: arch,
 	})
 	cad.Config.KubeConfig = oldKcfg
+	cad.ClusterConfig.KubeVersion = oldKver
 	if err != nil {
 		return "", "", err
 	}
@@ -634,7 +637,7 @@ func (cad *ClusterApiDriver) ensureImage(name string, arch string, version strin
 		CompartmentName:   compartmentId,
 		ImagePath:         imageName,
 		ImageName:         constants.OciImageName,
-		KubernetesVersion: cad.ClusterConfig.KubeVersion,
+		KubernetesVersion: version,
 		ImageArchitecture: arch,
 	})
 	if err != nil {

--- a/pkg/cluster/driver/capi/stage.go
+++ b/pkg/cluster/driver/capi/stage.go
@@ -182,6 +182,11 @@ func doUpdate(img *core.Image, arch string, version string, bvImage string) (boo
 				return false, nil
 			}
 
+			imgXport := alltransports.TransportFromImageName(containerImg)
+			if imgXport == nil {
+				containerImg = fmt.Sprintf("docker://%s", containerImg)
+			}
+
 			ockImgSpec, err := image.GetImageSpec(containerImg, arch)
 			if err != nil {
 				return false, err

--- a/pkg/cluster/template/templates/capi-oci.yaml
+++ b/pkg/cluster/template/templates/capi-oci.yaml
@@ -434,6 +434,7 @@ spec:
           tls-cipher-suites: {{.CipherSuite}}
     initConfiguration:
       skipPhases:
+      - "preflight"
       - "addon/kube-proxy"
       - "addon/coredns"
       patches:
@@ -446,6 +447,10 @@ spec:
           volume-plugin-dir: "{{.VolumePluginDir}}"
           tls-cipher-suites: {{.CipherSuite}}
     joinConfiguration:
+      skipPhases:
+      - "preflight"
+      patches:
+        directory: /etc/ocne/ock/patches
       discovery: {}
       nodeRegistration:
         criSocket: /var/run/crio/crio.sock

--- a/pkg/commands/node/update/scripts.go
+++ b/pkg/commands/node/update/scripts.go
@@ -12,16 +12,6 @@ chroot /hostroot /bin/bash <<"EOF"
   ostree admin deploy ock:ock
   systemctl stop ocne-update.service
 
-  {{ range $dir := .Directories }}
-  mkdir -p '{{ $dir }}'
-  {{end}}
-  {{ range $name, $tgt := .Symlinks}}
-  ln -s '{{ $tgt }}' '{{ $name }}'
-  {{end}}
-  {{ range $path, $contents := .Files }}
-  echo '{{ $contents }}' > '{{ $path }}'
-  {{end}}
-
   rpm-ostree kargs --delete-if-present=ignition.firstboot=1
   KUBECONFIG=/etc/kubernetes/kubelet.conf kubectl annotate node ${NODE_NAME} ocne.oracle.com/update-available-
   (sleep 3 && shutdown -r now)&


### PR DESCRIPTION
Kubernetes 1.31 is here.

Two issues are fixed in this PR
- `ocne cluster stage` for the oci provider can upload the wrong image version, preferring what is in defaults/cluster config vs the actual next version
- `ocne node update` can fail to un-cordon a control plane node if that node happens to be servicing the update request.
- `ocne node stage` for the oci provider can fail to add a transport when staging the same Kubernetes version.