### PR TITLE
Treat ignition/butane warnings as errors

### DIFF
--- a/pkg/cluster/ignition/ignition.go
+++ b/pkg/cluster/ignition/ignition.go
@@ -199,9 +199,11 @@ func FromBytes(in []byte) (*igntypes.Config, error) {
 	}
 
 	ret, report, err := ign34.ParseCompatibleVersion(in)
+
 	if len(report.String()) > 0 {
 		return nil, fmt.Errorf("could not parse extra ignition: %s", report.String())
 	}
+
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cluster/ignition/ignition.go
+++ b/pkg/cluster/ignition/ignition.go
@@ -186,7 +186,10 @@ func FromBytes(in []byte) (*igntypes.Config, error) {
 			Raw: true,
 		})
 
-		fmt.Println(report.String())
+		// Treat warnings as errors so that it's hard to propagate mistakes
+		if len(report.String()) > 0 {
+			return nil, fmt.Errorf("could not parse extra ignition: %s", report.String())
+		}
 
 		if err != nil {
 			return nil, err

--- a/pkg/cluster/ignition/ignition.go
+++ b/pkg/cluster/ignition/ignition.go
@@ -198,7 +198,10 @@ func FromBytes(in []byte) (*igntypes.Config, error) {
 		in = inIgn
 	}
 
-	ret, _, err := ign34.ParseCompatibleVersion(in)
+	ret, report, err := ign34.ParseCompatibleVersion(in)
+	if len(report.String()) > 0 {
+		return nil, fmt.Errorf("could not parse extra ignition: %s", report.String())
+	}
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
It can be hard to figure out why extra ignition is giving unexpected results.  Treat warnings as errors both to log the issue as well as to force end users to keep their ignition/butane configuration clean.

```
# Bad butane errors out
[opc@ol9 ocne]$ ./out/linux_amd64/ocne cluster start -c <( cat << EOF
> extraIgnitionInline: |
>   variant: fcos
>   version: 1.5.0
>   fakeKey: fakeVal
> EOF
> )
INFO[2025-02-26T15:11:57Z] Creating new Kubernetes cluster with version 1.31 named ocne 
ERRO[2025-02-26T15:11:57Z] could not parse extra ignition: warning at $.fakeKey, line 3 col 1: Unused key fakeKey 

# Good config works.
$ ./out/linux_amd64/ocne cluster start -c <(cat << EOF
> extraIgnitionInline: |
>   variant: fcos
  version: 1.5.0
  passwd:
    users:
      - name: dkrasins
        password_hash: "<omitted>"
        groups:
          - wheel
> EOF
> )
INFO[2025-02-26T15:17:47Z] Creating new Kubernetes cluster with version 1.31 named ocne 
INFO[2025-02-26T15:18:38Z] Waiting for the Kubernetes cluster to be ready: ok 
INFO[2025-02-26T15:18:39Z] Installing core-dns into kube-system: ok 
INFO[2025-02-26T15:18:39Z] Installing kube-proxy into kube-system: ok 
INFO[2025-02-26T15:18:40Z] Installing flannel into kube-flannel: ok 
INFO[2025-02-26T15:18:41Z] Installing ui into ocne-system: ok 
INFO[2025-02-26T15:18:41Z] Installing ocne-catalog into ocne-system: ok 
INFO[2025-02-26T15:18:41Z] Kubernetes cluster was created successfully  
INFO[2025-02-26T15:19:01Z] Waiting for the UI to be ready: ok 

Run the following command to create an authentication token to access the UI:
    KUBECONFIG='/home/opc/.kube/kubeconfig.ocne.local' kubectl create token ui -n ocne-system
Browser window opened, enter 'y' when ready to exit: y

INFO[2025-02-26T15:19:03Z] Post install information:

To access the cluster from the VM host:
    copy /home/opc/.kube/kubeconfig.ocne.vm to that host and run kubectl there
To access the cluster from this system:
    use /home/opc/.kube/kubeconfig.ocne.local
To access the UI, first do kubectl port-forward to allow the browser to access the UI.
Run the following command, then access the UI from the browser using via https://localhost:8443
    kubectl port-forward -n ocne-system service/ui 8443:443
Run the following command to create an authentication token to access the UI:
    kubectl create token ui -n ocne-system 
```