### PR TITLE
Allow custom OCI config profile

### DIFF
--- a/cmd/image/upload/upload.go
+++ b/cmd/image/upload/upload.go
@@ -61,6 +61,10 @@ const (
 	flagDestinationShort = "d"
 	flagDestinationHelp  = "The location to upload to"
 
+	flagProfile      = "profile"
+	flagProfileShort = "p"
+	flagProfileHelp  ="The name of the OCI configuration profile"
+
 	flagKubernetesVersionHelp = "The version of Kubernetes embedded in the image"
 )
 
@@ -89,6 +93,7 @@ func NewCmd() *cobra.Command {
 	cmd.Flags().StringVarP(&uploadOptions.ImageArchitecture, flags.FlagArchitecture, flags.FlagArchitectureShort, "", flagArchitectureHelp)
 	cmd.Flags().StringVarP(&uploadOptions.KubernetesVersion, constants.FlagVersionName, constants.FlagVersionShort, pkgconst.KubeVersion, flagKubernetesVersionHelp)
 	cmd.Flags().StringVarP(&uploadOptions.Destination, flagDestination, flagDestinationShort, "", flagDestinationHelp)
+	cmd.Flags().StringVarP(&uploadOptions.Profile, flagProfile, flagProfileShort, pkgconst.OciDefaultProfile, flagProfileHelp)
 
 	return cmd
 }

--- a/cmd/image/upload/upload.go
+++ b/cmd/image/upload/upload.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024, Oracle and/or its affiliates.
+// Copyright (c) 2024, 2025, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package upload

--- a/doc/manpages/ocne-config.yaml.md
+++ b/doc/manpages/ocne-config.yaml.md
@@ -205,6 +205,9 @@ providers:
     # be either the path to a compartment (e.g. mytenancy/mycompartment)
     # or the OCID of a compartment.
     compartment:
+    # The OCI configuration profile to use when opening
+    # OCI API connections.
+    profile: DEFAULT
     # The Kubernetes namespace where Cluster API resources
     # should be deploye.d
     namespace:

--- a/doc/manpages/ocne-defaults.yaml.md
+++ b/doc/manpages/ocne-defaults.yaml.md
@@ -142,6 +142,9 @@ providers:
     # be either the path to a compartment (e.g. mytenancy/mycompartment)
     # or the OCID of a compartment.
     compartment:
+    # The OCI configuration profile to use when opening
+    # OCI API connections.
+    profile: DEFAULT
     # The Kubernetes namespace where Cluster API resources
     # should be deploye.d
     namespace: ocne

--- a/doc/manpages/ocne-image.md
+++ b/doc/manpages/ocne-image.md
@@ -81,7 +81,8 @@ SUBCOMMANDS
     custom compute images.  Only applies to "oci" images.
 
 `-p`, `--profile` *profile*
-    The name of the OCI configuration profile to use when configuring OCI API clients.
+    The name of the OCI configuration profile to use when configuring OCI API
+    clients.  The default value is "DEFAULT".
 
 `-i`, `--image-name` *name*
     The name of the OCI custom compute image that is imported during upload.

--- a/doc/manpages/ocne-image.md
+++ b/doc/manpages/ocne-image.md
@@ -80,6 +80,9 @@ SUBCOMMANDS
     the correct OCID.  Uploaded images are imported to this compartment as
     custom compute images.  Only applies to "oci" images.
 
+`-p`, `--profile` *profile*
+    The name of the OCI configuration profile to use when configuring OCI API clients.
+
 `-i`, `--image-name` *name*
     The name of the OCI custom compute image that is imported during upload.
     The default is "ock".

--- a/pkg/cluster/driver/capi/capi.go
+++ b/pkg/cluster/driver/capi/capi.go
@@ -696,13 +696,13 @@ func (cad *ClusterApiDriver) ensureImages() error {
 		return err
 	}
 	if controlPlaneImageId != "" {
-		err = upload.EnsureImageDetails(compartmentId, controlPlaneImageId, controlPlaneArch, cad.ClusterConfig.Providers.Oci.Profile)
+		err = upload.EnsureImageDetails(compartmentId, cad.ClusterConfig.Providers.Oci.Profile, controlPlaneImageId, controlPlaneArch)
 		if err != nil {
 			return err
 		}
 	}
 	if workerImageId != "" {
-		err = upload.EnsureImageDetails(compartmentId, workerImageId, workerArch, cad.ClusterConfig.Providers.Oci.Profile)
+		err = upload.EnsureImageDetails(compartmentId, cad.ClusterConfig.Providers.Oci.Profile, workerImageId, workerArch)
 		if err != nil {
 			return err
 		}

--- a/pkg/cluster/driver/capi/capi.go
+++ b/pkg/cluster/driver/capi/capi.go
@@ -68,7 +68,7 @@ type ClusterApiDriver struct {
 }
 
 func (cad *ClusterApiDriver) getApplications() ([]install.ApplicationDescription, error) {
-	ociConfig, err := oci.GetConfig()
+	ociConfig, err := oci.GetConfig(cad.ClusterConfig.Providers.Oci.Profile)
 	if err != nil {
 		return nil, err
 	}
@@ -150,12 +150,12 @@ func (cad *ClusterApiDriver) getApplications() ([]install.ApplicationDescription
 }
 
 func (cad *ClusterApiDriver) getWorkloadClusterApplications(restConfig *rest.Config, kubeClient kubernetes.Interface) ([]install.ApplicationDescription, error) {
-	ociConfig, err := oci.GetConfig()
+	ociConfig, err := oci.GetConfig(cad.ClusterConfig.Providers.Oci.Profile)
 	if err != nil {
 		return nil, err
 	}
 
-	compartmentId, err := oci.GetCompartmentId(cad.ClusterConfig.Providers.Oci.Compartment)
+	compartmentId, err := oci.GetCompartmentId(cad.ClusterConfig.Providers.Oci.Compartment, cad.ClusterConfig.Providers.Oci.Profile)
 	if err != nil {
 		return nil, err
 	}
@@ -584,14 +584,14 @@ func CreateDriver(config *types.Config, clusterConfig *types.ClusterConfig) (dri
 }
 
 func (cad *ClusterApiDriver) ensureImage(name string, arch string, version string, force bool) (string, string, error) {
-	compartmentId, err := oci.GetCompartmentId(cad.ClusterConfig.Providers.Oci.Compartment)
+	compartmentId, err := oci.GetCompartmentId(cad.ClusterConfig.Providers.Oci.Compartment, cad.ClusterConfig.Providers.Oci.Profile)
 	if err != nil {
 		return "", "", err
 	}
 
 	// Check for a local image.  First see if there is already an image
 	// available in OCI
-	_, found, err := oci.GetImage(constants.OciImageName, version, arch, compartmentId)
+	_, found, err := oci.GetImage(constants.OciImageName, version, arch, compartmentId, cad.ClusterConfig.Providers.Oci.Profile)
 	if found && !force {
 		// An image was found.  Perfect.
 		return "", "", nil
@@ -651,7 +651,7 @@ func (cad *ClusterApiDriver) ensureImages() error {
 	controlPlaneArch := oci.ArchitectureFromShape(cad.ClusterConfig.Providers.Oci.ControlPlaneShape.Shape)
 	workerArch := oci.ArchitectureFromShape(cad.ClusterConfig.Providers.Oci.WorkerShape.Shape)
 
-	compartmentId, err := oci.GetCompartmentId(cad.ClusterConfig.Providers.Oci.Compartment)
+	compartmentId, err := oci.GetCompartmentId(cad.ClusterConfig.Providers.Oci.Compartment, cad.ClusterConfig.Providers.Oci.Profile)
 	if err != nil {
 		return err
 	}
@@ -691,18 +691,18 @@ func (cad *ClusterApiDriver) ensureImages() error {
 			imageImports[workerWorkRequest] = "Importing worker image"
 		}
 	}
-	err = oci.WaitForWorkRequests(imageImports)
+	err = oci.WaitForWorkRequests(imageImports, cad.ClusterConfig.Providers.Oci.Profile)
 	if err != nil {
 		return err
 	}
 	if controlPlaneImageId != "" {
-		err = upload.EnsureImageDetails(compartmentId, controlPlaneImageId, controlPlaneArch)
+		err = upload.EnsureImageDetails(compartmentId, controlPlaneImageId, controlPlaneArch, cad.ClusterConfig.Providers.Oci.Profile)
 		if err != nil {
 			return err
 		}
 	}
 	if workerImageId != "" {
-		err = upload.EnsureImageDetails(compartmentId, workerImageId, workerArch)
+		err = upload.EnsureImageDetails(compartmentId, workerImageId, workerArch, cad.ClusterConfig.Providers.Oci.Profile)
 		if err != nil {
 			return err
 		}

--- a/pkg/cluster/driver/capi/capi.go
+++ b/pkg/cluster/driver/capi/capi.go
@@ -633,6 +633,7 @@ func (cad *ClusterApiDriver) ensureImage(name string, arch string, version strin
 	// Image creation is done.  Upload it.
 	imageId, workRequestId, err := upload.UploadAsync(upload.UploadOptions{
 		ProviderType:      upload.ProviderTypeOCI,
+		Profile:           cad.ClusterConfig.Providers.Oci.Profile,
 		BucketName:        cad.ClusterConfig.Providers.Oci.ImageBucket,
 		CompartmentName:   compartmentId,
 		ImagePath:         imageName,

--- a/pkg/cluster/driver/capi/stage.go
+++ b/pkg/cluster/driver/capi/stage.go
@@ -411,7 +411,7 @@ func (cad *ClusterApiDriver) Stage(version string) (string, string, bool, error)
 
 	for _, img := range ociImages {
 		if img.WorkRequestId != "" {
-			err = upload.EnsureImageDetails(*img.Image.CompartmentId, img.NewId, img.Arch, cad.ClusterConfig.Providers.Oci.Profile)
+			err = upload.EnsureImageDetails(*img.Image.CompartmentId, cad.ClusterConfig.Providers.Oci.Profile, img.NewId, img.Arch)
 
 			if err != nil {
 				return "", "", false, err

--- a/pkg/cluster/template/oci/capi-oci.go
+++ b/pkg/cluster/template/oci/capi-oci.go
@@ -290,8 +290,9 @@ func GetOciTemplate(config *types.Config, clusterConfig *types.ClusterConfig) (s
 	// If the compartment name is non-empty
 	// resolve it to an ID.
 	cid := clusterConfig.Providers.Oci.Compartment
+	profile := clusterConfig.Providers.Oci.Profile
 	if cid != "" {
-		newCid, err := oci.GetCompartmentId(cid)
+		newCid, err := oci.GetCompartmentId(cid, profile)
 		if err != nil {
 			return "", err
 		}
@@ -299,12 +300,12 @@ func GetOciTemplate(config *types.Config, clusterConfig *types.ClusterConfig) (s
 		cid = newCid
 
 		// Try to resolve an Image ID.  Ignore errors.
-		img, _, err := oci.GetImage(constants.OciImageName, clusterConfig.KubeVersion, "amd64", cid)
+		img, _, err := oci.GetImage(constants.OciImageName, clusterConfig.KubeVersion, "amd64", cid, profile)
 		if img != nil {
 			clusterConfig.Providers.Oci.Images.Amd64 = *img.Id
 		}
 
-		img, _, err = oci.GetImage(constants.OciImageName, clusterConfig.KubeVersion, "arm64", cid)
+		img, _, err = oci.GetImage(constants.OciImageName, clusterConfig.KubeVersion, "arm64", cid, profile)
 		if img != nil {
 			clusterConfig.Providers.Oci.Images.Arm64 = *img.Id
 		}

--- a/pkg/commands/image/upload/types.go
+++ b/pkg/commands/image/upload/types.go
@@ -32,6 +32,9 @@ type UploadOptions struct {
 	// CompartmentName is the compartment where the image will get upload
 	CompartmentName string
 
+	// Profile is the OCI config profile
+	Profile string
+
 	// ImageName is the name of the custom image to create
 	ImageName string
 

--- a/pkg/commands/image/upload/types.go
+++ b/pkg/commands/image/upload/types.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024, Oracle and/or its affiliates.
+// Copyright (c) 2024, 2025, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package upload

--- a/pkg/commands/image/upload/upload.go
+++ b/pkg/commands/image/upload/upload.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024, Oracle and/or its affiliates.
+// Copyright (c) 2024, 2025, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package upload

--- a/pkg/commands/image/upload/upload.go
+++ b/pkg/commands/image/upload/upload.go
@@ -84,7 +84,7 @@ func UploadAsync(options UploadOptions) (string, string, error) {
 // EnsureImageDetails sets important configuration options for the custom image.
 // In particular, it sets the image schema to allow EFI and sets the image shapes
 // to match the architecture.
-func EnsureImageDetails(compartmentId string, imageId string, arch string, profile string) error {
+func EnsureImageDetails(compartmentId string, profile string, imageId string, arch string) error {
 	// Set schema.  compartmentId is set by UploadAsync
 	if err := oci.CreateEFIImageSchema(compartmentId, imageId, profile); err != nil {
 		return err
@@ -120,7 +120,7 @@ func UploadOci(options UploadOptions) error {
 	}
 
 	// Set schema.  compartmentId is set by UploadAsync
-	if err = EnsureImageDetails(options.compartmentId, imageId, options.ImageArchitecture, options.Profile); err != nil {
+	if err = EnsureImageDetails(options.compartmentId, options.Profile, imageId, options.ImageArchitecture); err != nil {
 		return err
 	}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024, Oracle and/or its affiliates.
+// Copyright (c) 2024, 2025, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package config

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -67,6 +67,7 @@ func GetDefaultConfig() (*types.Config, error) {
 			},
 			Oci: types.OciProvider{
 				Namespace:   "ocne",
+				Profile:     constants.OciDefaultProfile,
 				ImageBucket: constants.OciBucket,
 				ControlPlaneShape: types.OciInstanceShape{
 					Shape: constants.OciVmStandardA1Flex,

--- a/pkg/config/types/types.go
+++ b/pkg/config/types/types.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024, Oracle and/or its affiliates.
+// Copyright (c) 2024, 2025, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package types

--- a/pkg/config/types/types.go
+++ b/pkg/config/types/types.go
@@ -32,6 +32,7 @@ type OciImageSet struct {
 type OciProvider struct {
 	KubeConfigPath    string           `yaml:"kubeconfig"`
 	Compartment       string           `yaml:"compartment"`
+	Profile           string           `yaml:"profile"`
 	Namespace         string           `yaml:"namespace"`
 	ControlPlaneShape OciInstanceShape `yaml:"controlPlaneShape"`
 	Images            OciImageSet      `yaml:"images"`
@@ -440,6 +441,7 @@ func MergeOciProvider(def *OciProvider, ovr *OciProvider) OciProvider {
 	return OciProvider{
 		KubeConfigPath:    ies(def.KubeConfigPath, ovr.KubeConfigPath),
 		Compartment:       ies(def.Compartment, ovr.Compartment),
+		Profile:           ies(def.Profile, ovr.Profile),
 		Namespace:         ies(def.Namespace, ovr.Namespace),
 		Images:            MergeOciImageSet(&def.Images, &ovr.Images),
 		ImageBucket:       ies(def.ImageBucket, ovr.ImageBucket),

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -62,6 +62,9 @@ const (
 	OCIArchitectureTag      = "ocne/architecture"
 	OCIKubernetesVersionTag = "ocne/kubernetes"
 
+	// OCI Configuration Options
+	OciDefaultProfile   = "DEFAULT"
+
 	// OCNE annotations
 	OCNEAnnoUpdateAvailable = "ocne.oracle.com/update-available"
 
@@ -73,6 +76,7 @@ const (
 	ProviderTypeOCI     = "oci"
 	ProviderTypeOlvm    = "olvm"
 	ProviderTypeNone    = "none"
+
 )
 
 var OciArmCompatibleShapes = [...]string{OciVmStandardA1Flex, OciBmStandardA1160, OciVmStandardA2Flex}

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024, Oracle and/or its affiliates.
+// Copyright (c) 2024, 2025, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package constants

--- a/pkg/util/oci/compartment.go
+++ b/pkg/util/oci/compartment.go
@@ -16,7 +16,7 @@ import (
 // compartment1/compartment2/compartment3 and locates
 // the OCID of the indicated compartment by following
 // the path.
-func GetCompartmentId(compartmentName string) (string, error) {
+func GetCompartmentId(compartmentName string, profile string) (string, error) {
 	// If the name is already an OCID, just hand it back
 	if strings.HasPrefix(compartmentName, "ocid1.compartment") {
 		return compartmentName, nil
@@ -28,8 +28,7 @@ func GetCompartmentId(compartmentName string) (string, error) {
 		return "", fmt.Errorf("\"%s\" is not a valid compartment name", compartmentName)
 	}
 
-	dcp := common.DefaultConfigProvider()
-
+	dcp := common.CustomProfileConfigProvider("", profile)
 	idp, err := identity.NewIdentityClientWithConfigurationProvider(dcp)
 	if err != nil {
 		return "", err

--- a/pkg/util/oci/compartment.go
+++ b/pkg/util/oci/compartment.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024, Oracle and/or its affiliates.
+// Copyright (c) 2024, 2025, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oci

--- a/pkg/util/oci/config.go
+++ b/pkg/util/oci/config.go
@@ -103,7 +103,7 @@ func parseOciConfig(filename string) ([]*OciConfig, error) {
 	return ret, nil
 }
 
-func GetConfig() (*OciConfig, error) {
+func GetConfig(profile string) (*OciConfig, error) {
 	homedir, err := os.UserHomeDir()
 	if err != nil {
 		return nil, err
@@ -116,7 +116,7 @@ func GetConfig() (*OciConfig, error) {
 
 	var ret *OciConfig
 	for _, o := range sections {
-		if o.Name == "DEFAULT" {
+		if o.Name == profile {
 			ret = o
 			break
 		}

--- a/pkg/util/oci/config.go
+++ b/pkg/util/oci/config.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024, Oracle and/or its affiliates.
+// Copyright (c) 2024, 2025, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oci

--- a/pkg/util/oci/objectstorage.go
+++ b/pkg/util/oci/objectstorage.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024, Oracle and/or its affiliates.
+// Copyright (c) 2024, 2025, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oci

--- a/pkg/util/oci/objectstorage.go
+++ b/pkg/util/oci/objectstorage.go
@@ -14,9 +14,9 @@ import (
 )
 
 // GetNamespace returns the object storage namespace for this tenancy
-func GetNamespace() (string, error) {
+func GetNamespace(profile string) (string, error) {
 	ctx := context.Background()
-	c, err := objectstorage.NewObjectStorageClientWithConfigurationProvider(common.DefaultConfigProvider())
+	c, err := objectstorage.NewObjectStorageClientWithConfigurationProvider(common.CustomProfileConfigProvider("", profile))
 	if err != nil {
 		return "", err
 	}
@@ -33,14 +33,14 @@ func GetNamespace() (string, error) {
 // object is the same as the one that is desired.  If the object exists and
 // is the same, then the function simply returns.  If not, it uploads the
 // object to the given bucket and object name.
-func EnsureObject(bucketName string, objectName string, contentLen int64, content io.ReadCloser, metadata map[string]string) error {
-	namespace, err := GetNamespace()
+func EnsureObject(bucketName string, objectName string, profile string, contentLen int64, content io.ReadCloser, metadata map[string]string) error {
+	namespace, err := GetNamespace(profile)
 	if err != nil {
 		return err
 	}
 
 	ctx := context.Background()
-	c, err := objectstorage.NewObjectStorageClientWithConfigurationProvider(common.DefaultConfigProvider())
+	c, err := objectstorage.NewObjectStorageClientWithConfigurationProvider(common.CustomProfileConfigProvider("", profile))
 	if err != nil {
 		return err
 	}
@@ -63,18 +63,18 @@ func EnsureObject(bucketName string, objectName string, contentLen int64, conten
 		}
 	}
 
-	return UploadObject(bucketName, objectName, contentLen, content, metadata)
+	return UploadObject(bucketName, objectName, profile, contentLen, content, metadata)
 }
 
 // UploadObject uploads the contents of a stream to an object storage bucket
-func UploadObject(bucketName string, objectName string, contentLen int64, content io.ReadCloser, metadata map[string]string) error {
-	namespace, err := GetNamespace()
+func UploadObject(bucketName string, objectName string, profile string, contentLen int64, content io.ReadCloser, metadata map[string]string) error {
+	namespace, err := GetNamespace(profile)
 	if err != nil {
 		return err
 	}
 
 	ctx := context.Background()
-	c, err := objectstorage.NewObjectStorageClientWithConfigurationProvider(common.DefaultConfigProvider())
+	c, err := objectstorage.NewObjectStorageClientWithConfigurationProvider(common.CustomProfileConfigProvider("", profile))
 	if err != nil {
 		return err
 	}

--- a/pkg/util/oci/workrequests.go
+++ b/pkg/util/oci/workrequests.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024, Oracle and/or its affiliates.
+// Copyright (c) 2024, 2025, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oci

--- a/pkg/util/oci/workrequests.go
+++ b/pkg/util/oci/workrequests.go
@@ -46,7 +46,7 @@ func GetWorkRequestStatus(workRequestId string, profile string) (workrequests.Wo
 // WaitForWorkRequest waits for a work request to complete, while pretty
 // printing the progress.  If the work request fails, then an error
 // is returned.
-func WaitForWorkRequest(workRequestId string, prefix string, profile string) error {
+func WaitForWorkRequest(workRequestId string, profile string, prefix string) error {
 	return WaitForWorkRequests(map[string]string{workRequestId: prefix}, profile)
 }
 


### PR DESCRIPTION
A user may have an OCI configuration file with multiple profiles.  Switching between them today requires changing the profile to use to "DEFAULT".  This is annoying.  A profile can now be passed into all OCI API connections.

```
$ cat ~/.oci/config
[PROFILEONE]
...

[PROFILETWO]
...

[DEV]
...

$ ./out/linux_amd64/ocne image upload --compartment sandboxes/daniel.krasinski --bucket images --file /home/opc/.ocne/images/boot.qcow2-1.31-amd64.oci --arch amd64 --version 1.31 --profile DEV
INFO[2025-02-26T17:08:45Z] Uploading image to object storage: ok 
INFO[2025-02-26T17:22:45Z] Importing compute image: [##########]: ok 
INFO[2025-02-26T17:22:45Z] Image OCID is ocid1.image.oc1....


# Switch back to default
$ cat ~/.oci/config
[PROFILEONE]
...

[PROFILETWO]
...

[DEFAULT]
...

$ ./out/linux_amd64/ocne image upload --compartment sandboxes/daniel.krasinski --bucket images --file /home/opc/.ocne/images/boot.qcow2-1.31-amd64.oci --arch amd64 --version 1.31
INFO[2025-02-26T17:08:45Z] Uploading image to object storage: ok 
INFO[2025-02-26T17:22:45Z] Importing compute image: [##########]: ok 
INFO[2025-02-26T17:22:45Z] Image OCID is ocid1.image.oc1....

# Switch back to defaultless oci config
$ cat capi.yaml
...
providers:
  oci:
    profile: DEV

$ ocne cluster start -c capi.yaml
...
INFO[2025-02-26T19:01:50Z] Applying Cluster API resources               
INFO[2025-02-26T19:02:08Z] Waiting for kubeconfig: ok       
INFO[2025-02-26T19:03:48Z] Waiting for the Kubernetes cluster to be ready: ok 
INFO[2025-02-26T19:03:48Z] Installing applications into workload cluster 
INFO[2025-02-26T19:03:49Z] Installing oci-ccm into kube-system: ok 
INFO[2025-02-26T19:03:49Z] Found Control Plane Endpoint Host 100.101.68.20 
INFO[2025-02-26T19:03:49Z] Installing core-dns into kube-system: ok 
INFO[2025-02-26T19:03:50Z] Installing kube-proxy into kube-system: ok 
INFO[2025-02-26T19:03:50Z] Installing flannel into kube-flannel: ok 
INFO[2025-02-26T19:03:51Z] Installing ui into ocne-system: ok 
INFO[2025-02-26T19:03:52Z] Installing ocne-catalog into ocne-system: ok 
INFO[2025-02-26T19:03:52Z] Kubernetes cluster was created successfully  
...
```