### PR TITLE
Expand supported ostree tranports

### DIFF
--- a/pkg/image/registry_test.go
+++ b/pkg/image/registry_test.go
@@ -16,6 +16,7 @@ func TestParseOstreeReference(t *testing.T) {
 		[]string{"ostree-unverified-image:registry:container-registry.oracle.com/olcne/ock-ostree:1.30", "ostree-unverified-image:registry", "container-registry.oracle.com/olcne/ock-ostree", "1.30"},
 		[]string{"ostree-unverified-image:docker://container-registry.oracle.com/olcne/ock-ostree:1.30", "ostree-unverified-image:docker://", "container-registry.oracle.com/olcne/ock-ostree", "1.30"},
 		[]string{"ostree-unverified-image:containers-storage:container-registry.oracle.com/olcne/ock-ostree", "ostree-unverified-image:containers-storage", "container-registry.oracle.com/olcne/ock-ostree", ""},
+		[]string{"ostree-unverified-image:containers-storage:container-registry.oracle.com/olcne/ock-ostree:1.30", "ostree-unverified-image:containers-storage", "container-registry.oracle.com/olcne/ock-ostree", "1.30"},
 		[]string{"ostree-unverified-image:oci-archive:/var/archive.tar.gz", "ostree-unverified-image:oci-archive", "/var/archive.tar.gz", ""},
 		[]string{"ostree-unverified-registry:container-registry.oracle.com/olcne/ock-ostree", "ostree-unverified-registry", "container-registry.oracle.com/olcne/ock-ostree", ""},
 		[]string{"ostree-unverified-registry:container-registry.oracle.com/olcne/ock-ostree:1.30", "ostree-unverified-registry", "container-registry.oracle.com/olcne/ock-ostree", "1.30"},

--- a/pkg/image/registry_test.go
+++ b/pkg/image/registry_test.go
@@ -15,6 +15,8 @@ func TestParseOstreeReference(t *testing.T) {
 		[]string{"ostree-unverified-image:docker://container-registry.oracle.com/olcne/ock-ostree", "ostree-unverified-image:docker://", "container-registry.oracle.com/olcne/ock-ostree", ""},
 		[]string{"ostree-unverified-image:registry:container-registry.oracle.com/olcne/ock-ostree:1.30", "ostree-unverified-image:registry", "container-registry.oracle.com/olcne/ock-ostree", "1.30"},
 		[]string{"ostree-unverified-image:docker://container-registry.oracle.com/olcne/ock-ostree:1.30", "ostree-unverified-image:docker://", "container-registry.oracle.com/olcne/ock-ostree", "1.30"},
+		[]string{"ostree-unverified-image:containers-storage:container-registry.oracle.com/olcne/ock-ostree", "ostree-unverified-image:containers-storage", "container-registry.oracle.com/olcne/ock-ostree", ""},
+		[]string{"ostree-unverified-image:oci-archive:/var/archive.tar.gz", "ostree-unverified-image:oci-archive", "/var/archive.tar.gz", ""},
 		[]string{"ostree-unverified-registry:container-registry.oracle.com/olcne/ock-ostree", "ostree-unverified-registry", "container-registry.oracle.com/olcne/ock-ostree", ""},
 		[]string{"ostree-unverified-registry:container-registry.oracle.com/olcne/ock-ostree:1.30", "ostree-unverified-registry", "container-registry.oracle.com/olcne/ock-ostree", "1.30"},
 		[]string{"ostree-remote-image:remotename:docker://container-registry.oracle.com/olcne/ock-ostree", "ostree-remote-image:remotename:docker://", "container-registry.oracle.com/olcne/ock-ostree", ""},


### PR DESCRIPTION
As part of https://github.com/oracle-cne/ock/pull/23, OCK gained the ability to leverage more container image transports for updates.  The CLI needs to be updated to allow those to be automatically configured.