### PR TITLE
Ensure that kube-apiserver IP is valid for byo and none providers

### DIFF
--- a/pkg/cluster/driver/byo/byo.go
+++ b/pkg/cluster/driver/byo/byo.go
@@ -346,7 +346,7 @@ func (bd *ByoDriver) GetKubeconfigPath() string {
 }
 
 func (bd *ByoDriver) GetKubeAPIServerAddress() string {
-	return ""
+	return util.GetURIAddress(bd.getKubeAPIServerIP())
 }
 
 func (bd *ByoDriver) PostInstallHelpStanza() string {
@@ -358,13 +358,10 @@ func (bd *ByoDriver) DefaultCNIInterfaces() []string {
 }
 
 func (bd *ByoDriver) getKubeAPIServerIP() string {
-	addr := ""
 	if bd.Config.VirtualIp != "" {
-		addr = bd.Config.VirtualIp
-	} else {
-		addr = bd.Config.LoadBalancer
+		return bd.Config.VirtualIp
 	}
-	return util.GetURIAddress(addr)
+	return bd.Config.LoadBalancer
 }
 
 func (bd *ByoDriver) validateClusterConfig() error {

--- a/pkg/cluster/driver/none/none.go
+++ b/pkg/cluster/driver/none/none.go
@@ -4,10 +4,17 @@ package none
 
 import (
 	"fmt"
+	"net"
+	"strings"
+
+	"gopkg.in/yaml.v3"
 
 	"github.com/oracle-cne/ocne/pkg/cluster/driver"
 	"github.com/oracle-cne/ocne/pkg/config/types"
 	"github.com/oracle-cne/ocne/pkg/constants"
+	"github.com/oracle-cne/ocne/pkg/k8s"
+	"github.com/oracle-cne/ocne/pkg/k8s/client"
+	"github.com/oracle-cne/ocne/pkg/util"
 )
 
 const (
@@ -16,60 +23,102 @@ const (
 
 type NoneDriver struct {
 	KubeConfig string
+	KubeAPIServerIP string
 }
 
 func CreateDriver(config *types.Config, clusterConfig *types.ClusterConfig) (driver.ClusterDriver, error) {
 	if clusterConfig.Provider == constants.ProviderTypeNone && config.KubeConfig == "" {
 		return nil, fmt.Errorf("When the none provider is used, an existing kubeconfig file must be specified")
 	}
+
+	_, kubeIface, err := client.GetKubeClient(config.KubeConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	kubeadmConfigMap, err := k8s.GetConfigmap(kubeIface, constants.KubeNamespace, constants.KubeCMName)
+	if err != nil {
+		return nil, err
+	}
+
+	kubeadmConfig, ok := kubeadmConfigMap.Data[constants.KubeCMField]
+	if !ok {
+		return nil, fmt.Errorf("ConfigMap %s in namespace %s does not have a field named %s", constants.KubeCMName, constants.KubeNamespace, constants.KubeCMField)
+	}
+
+	confParsed := map[string]interface{}{}
+	err = yaml.Unmarshal([]byte(kubeadmConfig), confParsed)
+	if err != nil {
+		return nil, err
+	}
+
+	controlPlaneEndpointIface, ok := confParsed[constants.KubeCMEndpoint]
+	if !ok {
+		return nil, fmt.Errorf("ClusterConfiguration does not have a field named %s", constants.KubeCMEndpoint)
+	}
+
+	controlPlaneEndpoint, ok := controlPlaneEndpointIface.(string)
+	if !ok {
+		return nil, fmt.Errorf("ClusterConfiguration field %s is not a string", constants.KubeCMEndpoint)
+	}
+
+	kubeAPIServerIP, _, err := net.SplitHostPort(controlPlaneEndpoint)
+	if err != nil {
+		// Maybe there is no port.  If that is the
+		// error, assume that the value is a valid
+		// address.  If it's not, the cluster has
+		// bigger problems.
+		if !strings.Contains(err.Error(), "missing port in address") {
+			return nil, err
+		}
+		kubeAPIServerIP = controlPlaneEndpoint
+	} else {
+		// net.SplitHostPort removes any "[]" from IPv6 addresses.
+		// Add them back.
+		kubeAPIServerIP = util.GetURIAddress(kubeAPIServerIP)
+	}
+
 	ret := &NoneDriver{
-		KubeConfig: config.KubeConfig,
+		KubeConfig:      config.KubeConfig,
+		KubeAPIServerIP: kubeAPIServerIP,
 	}
 	return ret, nil
 }
+
 func (nd *NoneDriver) Start() (bool, bool, error) {
 	return true, false, nil
-
 }
 
 func (nd *NoneDriver) PostStart() error {
 	return nil
-
 }
 
 func (nd *NoneDriver) Stop() error {
 	return nil
-
 }
 
 func (nd *NoneDriver) Join(string, int, int) error {
 	return nil
-
 }
 
 func (nd *NoneDriver) Delete() error {
 	return nil
-
 }
 
 func (nd *NoneDriver) Close() error {
 	return nil
-
 }
 
 func (nd *NoneDriver) GetKubeconfigPath() string {
 	return nd.KubeConfig
-
 }
 
 func (nd *NoneDriver) GetKubeAPIServerAddress() string {
-	return ""
-
+	return nd.KubeAPIServerIP
 }
 
 func (nd *NoneDriver) PostInstallHelpStanza() string {
 	return ""
-
 }
 
 func (nd *NoneDriver) DefaultCNIInterfaces() []string {

--- a/pkg/cluster/update/update.go
+++ b/pkg/cluster/update/update.go
@@ -176,7 +176,6 @@ func updateKubeProxy(client kubernetes.Interface, kubeConfigPath string) error {
 		return err
 	}
 
-
 	// If the release was found, just update the tag.  That way the complex
 	// calculation of the configuration is avoided.
 	if proxyRelease != nil {

--- a/pkg/constants/k8s_constants.go
+++ b/pkg/constants/k8s_constants.go
@@ -143,6 +143,8 @@ const (
 	ScriptMountPath = "/ocne-scripts"
 	KubeNamespace   = "kube-system"
 	KubeCMName      = "kubeadm-config"
+	KubeCMField     = "ClusterConfiguration"
+	KubeCMEndpoint  = "controlPlaneEndpoint"
 	KubeletCMName   = "kubelet-config"
 
 )


### PR DESCRIPTION
There was a regression in [2.1.0](https://github.com/oracle-cne/ocne/pull/252) that prevents the cluster nodes from becoming ready.  When the kube-proxy application is installed, the address of the kube-apiserver is not actually set.  The result is that kube-proxy is unable to configure the service network that other pods (notably the CNI) require to communicate with kube-apiserver.  Net result: most pods cannot start.

The root cause of *that* is a failure to return a correct address for kube-apiserver from the byo and none providers.