### PR TITLE
Respect the mirror annotation from the catalog

### DIFF
--- a/pkg/catalog/types.go
+++ b/pkg/catalog/types.go
@@ -25,15 +25,16 @@ type CatalogConnection interface {
 // ChartMeta represents a single helm chart
 // NOTE: This structure is derived from the JSON return from the catalog service /charts/ endpoint
 type ChartMeta struct {
-	Name        string    `yaml:"name"`
-	Version     string    `yaml:"version"`
-	Description string    `yaml:"description"`
-	ApiVersion  string    `yaml:"apiVersion"`
-	AppVersion  string    `yaml:"appVersion"`
-	Type        string    `yaml:"type"`
-	Urls        []string  `yaml:"urls"`
-	Created     time.Time `yaml:"created"`
-	Digest      string    `yaml:"digest"`
+	Name        string             `yaml:"name"`
+	Version     string             `yaml:"version"`
+	Description string             `yaml:"description"`
+	ApiVersion  string             `yaml:"apiVersion"`
+	AppVersion  string             `yaml:"appVersion"`
+	Type        string             `yaml:"type"`
+	Urls        []string           `yaml:"urls"`
+	Created     time.Time          `yaml:"created"`
+	Digest      string             `yaml:"digest"`
+	Annotations map[string]string  `yaml:"annotations"`
 }
 
 // Catalog contains the helm chart index of all the charts in the catalog

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -77,6 +77,7 @@ const (
 	ProviderTypeOlvm    = "olvm"
 	ProviderTypeNone    = "none"
 
+	CatalogMirror = "ocne.oracle.com/mirror"
 )
 
 var OciArmCompatibleShapes = [...]string{OciVmStandardA1Flex, OciBmStandardA1160, OciVmStandardA2Flex}


### PR DESCRIPTION
Check the "ocne.oracle.com/mirror" annotation and don't add them to "ocne catalog mirror" if the annotation is "false".

```
$ ./out/linux_amd64/ocne catalog search --name embedded | grep kube-proxy
kube-proxy                 	2.0.0

$ ./out/linux_amd64/ocne catalog mirror | grep kube-proxy
$
```