### PR TITLE
update olvm template for new OCK image

### DIFF
--- a/pkg/cluster/template/olvm/ignition.go
+++ b/pkg/cluster/template/olvm/ignition.go
@@ -91,6 +91,11 @@ func getExtraIgnition(config *types.Config, clusterConfig *types.ClusterConfig, 
 		return "", err
 	}
 
+	patches, err := ignition.KubeadmPatches()
+	if err != nil {
+		return "", err
+	}
+
 	ign := ignition.NewIgnition()
 
 	// Cluster API has its own kubeadm service to start
@@ -164,6 +169,7 @@ func getExtraIgnition(config *types.Config, clusterConfig *types.ClusterConfig, 
 	ign = ignition.Merge(ign, container)
 	ign = ignition.Merge(ign, proxy)
 	ign = ignition.Merge(ign, usr)
+	ign = ignition.Merge(ign, patches)
 
 	// If an internal LB is needed for the control plane then the kubeconfig file
 	// needs to be copied to /etc/keepalived

--- a/pkg/cluster/template/templates/capi-olvm.yaml
+++ b/pkg/cluster/template/templates/capi-olvm.yaml
@@ -53,6 +53,9 @@ kind: KubeadmControlPlane
 metadata:
   name: "{{.ClusterConfig.Name}}-control-plane"
   namespace: "{{.ClusterConfig.Providers.Olvm.Namespace}}"
+  annotations:
+    controlplane.cluster.x-k8s.io/skip-kube-proxy: "true"
+    controlplane.cluster.x-k8s.io/skip-coredns: "true"
 spec:
   version: "{{.KubeVersions.Kubernetes}}"
   replicas: {{.ClusterConfig.ControlPlaneNodes}}
@@ -94,6 +97,12 @@ spec:
         extraArgs:
           tls-cipher-suites: {{.CipherSuite}}
     initConfiguration:
+      skipPhases:
+        - "preflight"
+        - "addon/kube-proxy"
+        - "addon/coredns"
+      patches:
+        directory: /etc/ocne/ock/patches
       localAPIEndpoint:
         bindPort: {{.ClusterConfig.Providers.Olvm.LocalAPIEndpoint.BindPort}}
         advertiseAddress: "{{.ClusterConfig.Providers.Olvm.LocalAPIEndpoint.AdvertiseAddress}}"
@@ -103,6 +112,10 @@ spec:
           volume-plugin-dir: "{{.VolumePluginDir}}"
           tls-cipher-suites: {{.CipherSuite}}
     joinConfiguration:
+      skipPhases:
+        - "preflight"
+      patches:
+        directory: /etc/ocne/ock/patches
       controlPlane:
         localAPIEndpoint:
           bindPort: {{.ClusterConfig.Providers.Olvm.LocalAPIEndpoint.BindPort}}

--- a/pkg/k8s/node.go
+++ b/pkg/k8s/node.go
@@ -15,8 +15,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
-	"github.com/oracle-cne/ocne/pkg/util/logutils"
 	"github.com/oracle-cne/ocne/pkg/util"
+	"github.com/oracle-cne/ocne/pkg/util/logutils"
 )
 
 const (
@@ -53,7 +53,7 @@ func WaitUntilGetNodesSucceeds(client kubernetes.Interface) (*v1.NodeList, error
 			Message: "Waiting for the Kubernetes cluster to be ready",
 			WaitFunction: func(ignored interface{}) error {
 				// wait for 10 min
-				maxTime := time.Now().Add(10 * time.Minute)
+				maxTime := time.Now().Add(15 * time.Minute)
 				for {
 					var err error
 					nodeList, err = GetNodeList(client)
@@ -167,7 +167,7 @@ func GetControlPlaneNodes(cli kubernetes.Interface) (*v1.NodeList, error) {
 // control plane nodes are available.  This is useful early in cluster
 // creation when even static pods have not been created.
 func WaitForControlPlaneNodes(cli kubernetes.Interface) (*v1.NodeList, error) {
-	list, _, err := util.LinearRetry(func(arg interface{})(interface{}, bool, error) {
+	list, _, err := util.LinearRetry(func(arg interface{}) (interface{}, bool, error) {
 		nodeList, err := GetControlPlaneNodes(cli)
 		if err != nil {
 			return nil, true, err
@@ -250,15 +250,14 @@ func processImage(registry string, best string, secondBest string, img *v1.Conta
 	return ret, haveBest, exactMatch
 }
 
-
 // GetImageCandidate returns a reasonable image:tag based on some criteria
-// - If the best match is found, the first return value is set to that image
-//   and the second return value is true
-// - If the second best match is found, the first return value is set to that
-//   image:tag and the third value is true
-// - If neither are found, an arbitrary image:tag is returned
-// - If the image does not exist on the node, the first value is the empty string
-//   and the other two are false.
+//   - If the best match is found, the first return value is set to that image
+//     and the second return value is true
+//   - If the second best match is found, the first return value is set to that
+//     image:tag and the third value is true
+//   - If neither are found, an arbitrary image:tag is returned
+//   - If the image does not exist on the node, the first value is the empty string
+//     and the other two are false.
 func GetImageCandidate(registry string, best string, secondBest string, node *v1.Node) (string, bool, bool) {
 	imgs := node.Status.Images
 	log.Debugf("%s has these images: %+v", node.Name, imgs)


### PR DESCRIPTION
Update the olvm CAPI client to work with new OCK image.  Cluster start was broken and is now fixed:

```
ocne cluster start --provider olvm  --cluster-name demo --config ~/.ocne/olvm-demo-cluster-config.yaml
 
INFO[2025-03-19T15:05:26-04:00] Installing cert-manager into cert-manager: ok 
INFO[2025-03-19T15:05:27-04:00] Installing core-capi into capi-system: ok 
INFO[2025-03-19T15:05:27-04:00] Installing olvm-capi into cluster-api-provider-olvm: ok 
INFO[2025-03-19T15:05:28-04:00] Installing bootstrap-capi into capi-kubeadm-bootstrap-system: ok 
INFO[2025-03-19T15:05:28-04:00] Installing control-plane-capi into capi-kubeadm-control-plane-system: ok 
INFO[2025-03-19T15:05:29-04:00] Waiting for Kubadm Control Plane Cluster API Controllers: ok 
INFO[2025-03-19T15:05:29-04:00] Waiting for Olvm Cluster API Controllers: ok 
INFO[2025-03-19T15:05:38-04:00] Waiting for Core Cluster API Controllers: ok 
INFO[2025-03-19T15:05:38-04:00] Waiting for Kubadm Boostrap Cluster API Controllers: ok 
INFO[2025-03-19T15:05:38-04:00] Applying Cluster API resources               
INFO[2025-03-19T15:05:40-04:00] Waiting for kubeconfig: ok       
INFO[2025-03-19T15:08:15-04:00] Waiting for the Kubernetes cluster to be ready: ok 
INFO[2025-03-19T15:08:15-04:00] Installing applications into workload cluster 
INFO[2025-03-19T15:08:20-04:00] Installing core-dns into kube-system: ok 
INFO[2025-03-19T15:08:23-04:00] Installing kube-proxy into kube-system: ok 
INFO[2025-03-19T15:08:25-04:00] Installing kubernetes-gateway-api-crds into kube-system: ok 
INFO[2025-03-19T15:08:28-04:00] Installing flannel into kube-flannel: ok 
INFO[2025-03-19T15:08:31-04:00] Installing ui into ocne-system: ok 
INFO[2025-03-19T15:08:33-04:00] Installing ocne-catalog into ocne-system: ok 
INFO[2025-03-19T15:08:33-04:00] Kubernetes cluster was created successfully  
INFO[2025-03-19T15:11:45-04:00] Waiting for the UI to be ready: ok 
```

Get nodes and pods
```
kk get node 
NAME                       STATUS   ROLES           AGE    VERSION
demo-control-plane-nlv2z   Ready    control-plane   10m    v1.31.6+1.el8
demo-md-0-llrdd-z7lcv      Ready    <none>          8m1s   v1.31.6+1.el8

kk get pod -A 
NAMESPACE      NAME                                               READY   STATUS    RESTARTS      AGE
kube-flannel   kube-flannel-ds-bnf2k                              1/1     Running   0             4m12s
kube-flannel   kube-flannel-ds-gpwnh                              1/1     Running   1 (75s ago)   107s
kube-system    coredns-7dcb9db977-szg52                           1/1     Running   0             4m19s
kube-system    coredns-7dcb9db977-xvqv7                           1/1     Running   0             4m19s
kube-system    etcd-demo-control-plane-nlv2z                      1/1     Running   0             4m36s
kube-system    kube-apiserver-demo-control-plane-nlv2z            1/1     Running   0             4m36s
kube-system    kube-controller-manager-demo-control-plane-nlv2z   1/1     Running   0             4m34s
kube-system    kube-proxy-568qk                                   1/1     Running   0             107s
kube-system    kube-proxy-9jfms                                   1/1     Running   0             4m16s
kube-system    kube-scheduler-demo-control-plane-nlv2z            1/1     Running   0             4m29s
ocne-system    ocne-catalog-8c94cc49f-hndp7                       1/1     Running   0             4m6s
ocne-system    ui-5f59d8454b-bxqgc                                1/1     Running   0             4m8s
```