### PR TITLE
Make image upload for oci images account for cluster config and defaults

### DIFF
--- a/cmd/image/upload/upload.go
+++ b/cmd/image/upload/upload.go
@@ -98,12 +98,23 @@ func NewCmd() *cobra.Command {
 	return cmd
 }
 
+func ovrIfSet(src string, dest *string) {
+	if src != "" {
+		*dest = src
+	}
+}
+
 // RunCmd runs the "ocne image upload" command
 func RunCmd(cmd *cobra.Command) error {
 	_, cc, err := cmdutil.GetFullConfig(&config, &clusterConfig, clusterConfigPath)
 	if err != nil {
 		return err
 	}
+
+	// If any command lines values are provided, they override the cluster config
+	ovrIfSet(uploadOptions.BucketName, &cc.Providers.Oci.ImageBucket)
+	ovrIfSet(uploadOptions.CompartmentName, &cc.Providers.Oci.Compartment)
+	ovrIfSet(uploadOptions.Profile, &cc.Providers.Oci.Profile)
 
 	uploadOptions.ClusterConfig = cc
 	if err := flags.ValidateArchitecture(uploadOptions.ImageArchitecture); err != nil {

--- a/pkg/commands/image/upload/upload.go
+++ b/pkg/commands/image/upload/upload.go
@@ -27,7 +27,7 @@ func setCompartmentId(options *UploadOptions) error {
 		return nil
 	}
 
-	compartmentId, err := oci.GetCompartmentId(options.CompartmentName, options.Profile)
+	compartmentId, err := oci.GetCompartmentId(options.ClusterConfig.Providers.Oci.Compartment, options.ClusterConfig.Providers.Oci.Profile)
 	if err != nil {
 		return err
 	}
@@ -70,7 +70,7 @@ func UploadAsync(options UploadOptions) (string, string, error) {
 			Message: "Uploading image to object storage",
 			WaitFunction: func(uIface interface{}) error {
 				uo, _ := uIface.(*UploadOptions)
-				return oci.UploadObject(uo.BucketName, options.filename, uo.Profile, uo.size, uo.file, nil)
+				return oci.UploadObject(uo.ClusterConfig.Providers.Oci.ImageBucket, options.filename, uo.ClusterConfig.Providers.Oci.Profile, uo.size, uo.file, nil)
 			},
 		},
 	})
@@ -78,7 +78,7 @@ func UploadAsync(options UploadOptions) (string, string, error) {
 		return "", "", fmt.Errorf("Failed to upload image to object storage")
 	}
 
-	return oci.ImportImage(options.ImageName, options.KubernetesVersion, options.ImageArchitecture, options.compartmentId, options.BucketName, options.filename, options.Profile)
+	return oci.ImportImage(options.ImageName, options.KubernetesVersion, options.ImageArchitecture, options.compartmentId, options.ClusterConfig.Providers.Oci.ImageBucket, options.filename, options.Profile)
 }
 
 // EnsureImageDetails sets important configuration options for the custom image.


### PR DESCRIPTION
It's a hassle to always have to provide CLI arguments when uploading OCI images.  Usually the cluster config or defaults file have that information in them already.  It is now possible to consume these values straight out of the cluster config.

```
# Notice that the compartment argument is not specified.
$ ocne image upload --version 1.29 --type oci --file ~/.ocne/images/boot.qcow2-1.29-amd64.oci --arch amd64
INFO[2025-03-20T16:49:14Z] Uploading image to object storage: ok 
INFO[2025-03-20T17:03:01Z] Importing compute image: [##########]: ok 
INFO[2025-03-20T17:03:01Z] Image OCID is ocid1.image.oc1.iad.aaaaaaaaaaaaaaaaaaaaa

# CLI options still need to work, of course
$ ocne image upload --version 1.29 --type oci --file ~/.ocne/images/boot.qcow2-1.29-amd64.oci --arch amd64 --compartment afakecompartmenttoproveclioverrides
ERRO[2025-03-20T17:13:24Z] could not find compartment named afakecompartmenttoproveclioverrides in afakecompartmenttoproveclioverrides
```

It has also become clear that the custom image name should be configurable via the oci provider configuration. I've filed #323