### PR TITLE
Tighten up file permissions for virtual ip

### DIFF
--- a/buildrpm/ocne.spec
+++ b/buildrpm/ocne.spec
@@ -6,7 +6,7 @@
 
 Name: ocne
 Version: 2.1.2
-Release: 2%{dist}
+Release: 3%{dist}
 Vendor: Oracle America
 Summary: Oracle Cloud Native Environment command line interface
 License: UPL 1.0
@@ -71,6 +71,9 @@ chmod 755 %{buildroot}%{_sysconfdir}/bash_completion.d/ocne
 %{_sysconfdir}/bash_completion.d/ocne
 
 %changelog
+* Mon Mar 31 2025 Daniel Krasinski <daniel.krasinski@oracle.com> - 2.1.2-3
+- Improve the initial deployment of keepalived and nginx for virtual IP deployments
+
 * Tue Mar 25 2025 Michael Gianatassio <michael.gianatassio@oracle.com> - 2.1.2-2
 - Fix a segmentation fault when automatically uploading custom images with the oci provider
 

--- a/pkg/cluster/ignition/ignition.go
+++ b/pkg/cluster/ignition/ignition.go
@@ -30,6 +30,8 @@ type File struct {
 	Path       string       `json:"path"`
 	Filesystem string       `json:"filesystem"`
 	Mode       int          `json:"mode"`
+	UserId     int       `json:"user"`
+	GroupId    int       `json:"group"`
 	Contents   FileContents `json:"contents"`
 	encoded    bool
 	Overwrite  bool ` json:"overwrite"`
@@ -116,6 +118,12 @@ func AddFile(ign *igntypes.Config, f *File) error {
 		Node: igntypes.Node{
 			Path:      f.Path,
 			Overwrite: util.BoolPtr(true),
+			User: igntypes.NodeUser{
+				ID: util.IntPtr(f.UserId),
+			},
+			Group: igntypes.NodeGroup{
+				ID: util.IntPtr(f.GroupId),
+			},
 		},
 		FileEmbedded1: igntypes.FileEmbedded1{
 			Mode: util.IntPtr(f.Mode),

--- a/pkg/cluster/ignition/ignition.go
+++ b/pkg/cluster/ignition/ignition.go
@@ -30,8 +30,10 @@ type File struct {
 	Path       string       `json:"path"`
 	Filesystem string       `json:"filesystem"`
 	Mode       int          `json:"mode"`
-	UserId     int       `json:"user"`
-	GroupId    int       `json:"group"`
+	UserId     int          `json:"user"`
+	User       string       `json:"username"`
+	GroupId    int          `json:"group"`
+	Group      string       `json:"groupname"`
 	Contents   FileContents `json:"contents"`
 	encoded    bool
 	Overwrite  bool ` json:"overwrite"`
@@ -114,15 +116,35 @@ func AddFile(ign *igntypes.Config, f *File) error {
 		return err
 	}
 
+	var uidPtr *int
+	var gidPtr *int
+	var unamePtr *string
+	var gnamePtr *string
+
+	if f.UserId != 0 {
+		uidPtr = util.IntPtr(f.UserId)
+	}
+	if f.User != "" {
+		unamePtr = util.StrPtr(f.User)
+	}
+	if f.GroupId != 0 {
+		gidPtr = util.IntPtr(f.GroupId)
+	}
+	if f.Group != "" {
+		gnamePtr = util.StrPtr(f.Group)
+	}
+
 	ign.Storage.Files = append(ign.Storage.Files, igntypes.File{
 		Node: igntypes.Node{
 			Path:      f.Path,
 			Overwrite: util.BoolPtr(true),
 			User: igntypes.NodeUser{
-				ID: util.IntPtr(f.UserId),
+				ID: uidPtr,
+				Name: unamePtr,
 			},
 			Group: igntypes.NodeGroup{
-				ID: util.IntPtr(f.GroupId),
+				ID: gidPtr,
+				Name: gnamePtr,
 			},
 		},
 		FileEmbedded1: igntypes.FileEmbedded1{

--- a/pkg/cluster/ignition/virtual_ip.go
+++ b/pkg/cluster/ignition/virtual_ip.go
@@ -13,6 +13,9 @@ import (
 
 const (
 	keepAlivedServiceName = "keepalived.service"
+	keepAlivedUid = 991
+	keepAlivedUser = "keepalived_script"
+	keepAlivedGroup = "keepalived_script"
 
 	nginxServiceName = "ocne-nginx.service"
 
@@ -272,8 +275,8 @@ func GenerateAssetsForVirtualIp(bindPort uint16, altPort uint16, virtualIP strin
 			Contents: FileContents{
 				Source: keepAlivedConfig,
 			},
-			UserId: 991,
-			GroupId: 991,
+			User: keepAlivedUser,
+			Group: keepAlivedGroup,
 		},
 		&File{
 			Path: KeepAlivedConfigTemplatePath,
@@ -291,8 +294,8 @@ func GenerateAssetsForVirtualIp(bindPort uint16, altPort uint16, virtualIP strin
 		&File{
 			Path: keepAlivedCheckScriptPath,
 			Mode: 0755,
-			UserId: 991,
-			GroupId: 991,
+			User: keepAlivedUser,
+			Group: keepAlivedGroup,
 			Contents: FileContents{
 				Source: keepAlivedCheckScript,
 			},
@@ -300,8 +303,8 @@ func GenerateAssetsForVirtualIp(bindPort uint16, altPort uint16, virtualIP strin
 		&File{
 			Path: keepAlivedStateScriptPath,
 			Mode: 0755,
-			UserId: 991,
-			GroupId: 991,
+			User: keepAlivedUser,
+			Group: keepAlivedGroup,
 			Contents: FileContents{
 				Source: keepAlivedStateScript,
 			},
@@ -309,8 +312,8 @@ func GenerateAssetsForVirtualIp(bindPort uint16, altPort uint16, virtualIP strin
 		&File{
 			Path: "/etc/keepalived/peers",
 			Mode: 0644,
-			UserId: 991,
-			GroupId: 991,
+			User: keepAlivedUser,
+			Group: keepAlivedGroup,
 			Contents: FileContents{
 				Source: "",
 			},
@@ -318,8 +321,8 @@ func GenerateAssetsForVirtualIp(bindPort uint16, altPort uint16, virtualIP strin
 		&File{
 			Path: "/etc/keepalived/log",
 			Mode: 0644,
-			UserId: 991,
-			GroupId: 991,
+			User: keepAlivedUser,
+			Group: keepAlivedGroup,
 			Contents: FileContents{
 				Source: "",
 			},
@@ -339,8 +342,8 @@ func GenerateAssetsForVirtualIp(bindPort uint16, altPort uint16, virtualIP strin
 		&File{
 			Path: nginxConfigPath,
 			Mode: 0644,
-			UserId: 991,
-			GroupId: 991,
+			User: keepAlivedUser,
+			Group: keepAlivedGroup,
 			Contents: FileContents{
 				Source: nginxConfig,
 			},
@@ -376,8 +379,8 @@ func GenerateAssetsForVirtualIp(bindPort uint16, altPort uint16, virtualIP strin
 		&File{
 			Path: "/etc/ocne/nginx/servers",
 			Mode: 0644,
-			UserId: 991,
-			GroupId: 991,
+			User: keepAlivedUser,
+			Group: keepAlivedGroup,
 			Contents: FileContents{
 				Source: "",
 			},

--- a/pkg/cluster/ignition/virtual_ip.go
+++ b/pkg/cluster/ignition/virtual_ip.go
@@ -45,7 +45,7 @@ vrrp_instance VI_1 {
   virtual_router_id 51
   priority {{ .Priority }}
   unicast_peer {
-PEERS
+{{ .Peers }}
   }
   virtual_ipaddress {
     {{ .VirtualIP }}
@@ -80,6 +80,7 @@ refreshServices() {
     echo "$NODES" > /etc/keepalived/peers
 
     ADDRS=$(/usr/sbin/ip addr)
+    ADDRS="$ADDRS localhost"
     ESCAPED_PEERS=""
     for node in $NODES; do
       echo "$ADDRS" | grep -q "$node"
@@ -128,7 +129,7 @@ events {
 }
 stream {
   upstream backend1 {
-SERVERS
+{{ .Peer }}
   }
   server {
     listen {{ .BindPort }};
@@ -199,6 +200,7 @@ type keepalivedConfigArguments struct {
 	Iface     string
 	Priority  string
 	VirtualIP string
+	Peers     string
 }
 
 type keepalivedCheckScriptArguments struct {
@@ -208,23 +210,26 @@ type keepalivedCheckScriptArguments struct {
 
 type nginxConfigArguments struct {
 	BindPort string
+	Peer     string
 }
 
 // generateNginxConfig generates a configuration file for nginx to load balaance between
 // all the master nodes in a given cluster.
-func generateNginxConfig(bindPort uint16) (string, error) {
+func generateNginxConfig(bindPort uint16, peer string) (string, error) {
 	return util.TemplateToString(nginxConfig, &nginxConfigArguments{
 		BindPort: fmt.Sprintf("%d", bindPort),
+		Peer:     peer,
 	})
 }
 
 // generateKeepalivedConfig creates a config file that managed a virtual ip between all kubernetes
 // master nodes.
-func generateKeepalivedConfig(iface string, priority string, virtualIP string) (string, error) {
+func generateKeepalivedConfig(iface string, priority string, virtualIP string, peers string) (string, error) {
 	return util.TemplateToString(keepalivedConfigTemplate, &keepalivedConfigArguments{
 		Iface:     iface,
 		Priority:  priority,
 		VirtualIP: virtualIP,
+		Peers:     peers,
 	})
 }
 
@@ -250,23 +255,31 @@ func GenerateAssetsForVirtualIp(bindPort uint16, altPort uint16, virtualIP strin
 		Units: []*igntypes.Unit{},
 	}
 
-	keepAlivedConfig, err := generateKeepalivedConfig(netInterface, "50", virtualIP)
+	keepAlivedConfig, err := generateKeepalivedConfig(netInterface, "50", virtualIP, "")
 	if err != nil {
 		return nil, err
 	}
+
+	keepAlivedConfigTemplate, err := generateKeepalivedConfig(netInterface, "50", virtualIP, "PEERS")
+	if err != nil {
+		return nil, err
+	}
+
 	data.Files = append(data.Files,
 		&File{
 			Path: keepAlivedConfigPath,
-			Mode: 0666,
+			Mode: 0644,
 			Contents: FileContents{
 				Source: keepAlivedConfig,
 			},
+			UserId: 991,
+			GroupId: 991,
 		},
 		&File{
 			Path: KeepAlivedConfigTemplatePath,
 			Mode: 0644,
 			Contents: FileContents{
-				Source: keepAlivedConfig,
+				Source: keepAlivedConfigTemplate,
 			},
 		})
 
@@ -278,6 +291,8 @@ func GenerateAssetsForVirtualIp(bindPort uint16, altPort uint16, virtualIP strin
 		&File{
 			Path: keepAlivedCheckScriptPath,
 			Mode: 0755,
+			UserId: 991,
+			GroupId: 991,
 			Contents: FileContents{
 				Source: keepAlivedCheckScript,
 			},
@@ -285,33 +300,47 @@ func GenerateAssetsForVirtualIp(bindPort uint16, altPort uint16, virtualIP strin
 		&File{
 			Path: keepAlivedStateScriptPath,
 			Mode: 0755,
+			UserId: 991,
+			GroupId: 991,
 			Contents: FileContents{
 				Source: keepAlivedStateScript,
 			},
 		},
 		&File{
 			Path: "/etc/keepalived/peers",
-			Mode: 0666,
+			Mode: 0644,
+			UserId: 991,
+			GroupId: 991,
 			Contents: FileContents{
 				Source: "",
 			},
 		},
 		&File{
 			Path: "/etc/keepalived/log",
-			Mode: 0666,
+			Mode: 0644,
+			UserId: 991,
+			GroupId: 991,
 			Contents: FileContents{
 				Source: "",
 			},
 		})
 
-	nginxConfig, err := generateNginxConfig(bindPort)
+	nginxConfig, err := generateNginxConfig(bindPort, fmt.Sprintf("    server localhost:%d;", altPort))
 	if err != nil {
 		return nil, err
 	}
+
+	nginxConfigTemplate, err := generateNginxConfig(bindPort, "SERVERS")
+	if err != nil {
+		return nil, err
+	}
+
 	data.Files = append(data.Files,
 		&File{
 			Path: nginxConfigPath,
-			Mode: 0666,
+			Mode: 0644,
+			UserId: 991,
+			GroupId: 991,
 			Contents: FileContents{
 				Source: nginxConfig,
 			},
@@ -320,7 +349,7 @@ func GenerateAssetsForVirtualIp(bindPort uint16, altPort uint16, virtualIP strin
 			Path: nginxConfigTemplatePath,
 			Mode: 0644,
 			Contents: FileContents{
-				Source: nginxConfig,
+				Source: nginxConfigTemplate,
 			},
 		},
 		&File{
@@ -346,7 +375,9 @@ func GenerateAssetsForVirtualIp(bindPort uint16, altPort uint16, virtualIP strin
 		},
 		&File{
 			Path: "/etc/ocne/nginx/servers",
-			Mode: 0666,
+			Mode: 0644,
+			UserId: 991,
+			GroupId: 991,
 			Contents: FileContents{
 				Source: "",
 			},


### PR DESCRIPTION
The permissions on some configuration files for keepalived and nginx are too loose.  Tighten them up.  Since I was already in there, I made the default configuration files function from the get go as well.