### PR TITLE
Correct mis-merge of main branch into release branch

### DIFF
--- a/pkg/commands/cluster/start/start.go
+++ b/pkg/commands/cluster/start/start.go
@@ -259,16 +259,6 @@ func Start(config *types.Config, clusterConfig *types.ClusterConfig) (string, er
 				},
 			},
 		},
-		install.ApplicationDescription{
-			Force: true,
-			Application: &types.Application{
-				Name:      constants.KubernetesGatewayAPICrds,
-				Namespace: constants.KubeNamespace,
-				Release:   constants.KubernetesGatewayAPICrds,
-				Version:   constants.KubernetesGatewayAPICrdsVersion,
-				Catalog:   catalog.InternalCatalog,
-			},
-		},
 	}
 
 	// If the Kubernetes Gateway APIs support the installed version,


### PR DESCRIPTION
During the merging of main -> release/2.1 for release 2.1.2, the auto-merge appeared to succeed but actually introduced some breakage.  The gateway crd chart was being installed twice.  It's mostly cosmetic, as the same chart is re-installed immediately after the first install during cluster start, which is why it was missed during testing.