### PR TITLE
Add error message toleration to oci provider logging

### DIFF
--- a/buildrpm/ocne.spec
+++ b/buildrpm/ocne.spec
@@ -6,7 +6,7 @@
 
 Name: ocne
 Version: 2.1.2
-Release: 3%{dist}
+Release: 4%{dist}
 Vendor: Oracle America
 Summary: Oracle Cloud Native Environment command line interface
 License: UPL 1.0
@@ -71,6 +71,9 @@ chmod 755 %{buildroot}%{_sysconfdir}/bash_completion.d/ocne
 %{_sysconfdir}/bash_completion.d/ocne
 
 %changelog
+* Wed Apr 02 2025 Daniel Krasinski <daniel.krasinski@oracle.com> - 2.1.2-4
+- Tolerate errors from the OCI CAPI controllers that are very short lived
+
 * Mon Mar 31 2025 Daniel Krasinski <daniel.krasinski@oracle.com> - 2.1.2-3
 - Improve the initial deployment of keepalived and nginx for virtual IP deployments
 

--- a/pkg/cluster/driver/capi/logScanner.go
+++ b/pkg/cluster/driver/capi/logScanner.go
@@ -26,7 +26,7 @@ var tolerations []*regexp.Regexp = []*regexp.Regexp{
 	// some goop to match '\"'.
 	// \\\\\" -> \\ escapes the next backslash \\ literal backslash \" escapes the quote
 	// In each pair, the first backslash is for the string escaping.
-	regexp.MustCompile("OCICluster.infrastructure.cluster.x-k8s.io \\\\\".*\\\\\" not found"),
+	regexp.MustCompile("OCICluster\\.infrastructure\\.cluster\\.x-k8s\\.io \\\\\".*\\\\\" not found"),
 }
 
 func (olh *OciLogHandler) Handle(lines []string) {


### PR DESCRIPTION
When applying CAPI resources to a management cluster, not all resources are made in a timely fashion.  This can cause some transient failures in various controllers as the resource state shakes out.

For example
```
...
INFO[2025-04-02T18:59:46Z] Applying Cluster API resources               
ERRO[2025-04-02T18:59:46Z] Saw unexpected error message in OCI Cluster API provider logs: E0402 18:59:46.049435       1 ocicluster_controller.go:315] "Failed to get OCI cluster" err="OCICluster.infrastructure.cluster.x-k8s.io \"capi\" not found" 
INFO[2025-04-02T19:00:29Z] Waiting for kubeconfig: ok  
...
```

These should be tolerated.  Right now the list is limited to the one example that I have seen.  This check can be expanded as more examples are found.