### PR TITLE
Retry fetching kubelet-config during cluster start

### DIFF
--- a/buildrpm/ocne.spec
+++ b/buildrpm/ocne.spec
@@ -6,7 +6,7 @@
 
 Name: ocne
 Version: 2.1.2
-Release: 4%{dist}
+Release: 5%{dist}
 Vendor: Oracle America
 Summary: Oracle Cloud Native Environment command line interface
 License: UPL 1.0
@@ -71,6 +71,9 @@ chmod 755 %{buildroot}%{_sysconfdir}/bash_completion.d/ocne
 %{_sysconfdir}/bash_completion.d/ocne
 
 %changelog
+* Wed Apr 02 2025 Daniel Krasinski <daniel.krasinski@oracle.com> - 2.1.2-5
+- Add a retry for fetching the kubelet-config during cluster start to account for slow controllers
+
 * Wed Apr 02 2025 Daniel Krasinski <daniel.krasinski@oracle.com> - 2.1.2-4
 - Tolerate errors from the OCI CAPI controllers that are very short lived
 

--- a/pkg/cluster/driver/capi/capi.go
+++ b/pkg/cluster/driver/capi/capi.go
@@ -1170,7 +1170,7 @@ func (cad *ClusterApiDriver) GetKubeAPIServerAddress() string {
 	}
 
 	ret, _, err := unstructured.NestedString(cluster.Object, OCIClusterControlPlaneEndpointHost...)
-	log.Infof("Found Control Plane Endpoint Host %s", ret)
+	log.Debugf("Found Control Plane Endpoint Host %s", ret)
 	if err != nil {
 		log.Errorf("Could not get Kubernetes API Server address: %+v", err)
 		return ""

--- a/pkg/commands/cluster/start/start.go
+++ b/pkg/commands/cluster/start/start.go
@@ -199,7 +199,7 @@ func Start(config *types.Config, clusterConfig *types.ClusterConfig) (string, er
 		return localKubeConfig, err
 	}
 
-	kubeletConfig, err := k8s.GetKubeletConfig(kubeClient)
+	kubeletConfig, err := k8s.WaitForKubeletConfig(kubeClient)
 	if err != nil {
 		return localKubeConfig, err
 	}


### PR DESCRIPTION
If your network connection is flaky, the CAPI controllers can take a while to put the kubelet-config ConfigMap into the cluster.  Best to wait for it for the sake of reliability.