### PR TITLE
Fix issue of ocne application update not properly reusing user supplied overrides

### DIFF
--- a/pkg/helm/helmcli.go
+++ b/pkg/helm/helmcli.go
@@ -215,10 +215,7 @@ func UpgradeChart(kubeInfo *client.KubeInfo, releaseName string, namespace strin
 		// Reuse the original set of input values as the base set of helm overrides
 		helmValues := map[string]interface{}{}
 		if !resetValues {
-			helmValues, err = GetValuesMap(kubeInfo, releaseName, namespace)
-			if err != nil {
-				return nil, err
-			}
+			client.ReuseValues = true
 		}
 
 		// Append the new override values

--- a/pkg/helm/helmcli.go
+++ b/pkg/helm/helmcli.go
@@ -6,6 +6,7 @@ package helm
 import (
 	"fmt"
 	"io"
+	"maps"
 	"net/url"
 	"os"
 	"regexp"
@@ -215,15 +216,16 @@ func UpgradeChart(kubeInfo *client.KubeInfo, releaseName string, namespace strin
 		// Reuse the original set of input values as the base set of helm overrides
 		helmValues := map[string]interface{}{}
 		if !resetValues {
-			client.ReuseValues = true
+			helmValues, err = GetValuesMap(kubeInfo, releaseName, namespace)
+			if err != nil {
+				return nil, err
+			}
 		}
 
-		// Append the new override values
-		for k, v := range vals {
-			helmValues[k] = v
-		}
+		// Merge the overrides
+		mergedValues := mergeOverrides(helmValues, vals)
 
-		rel, err = client.Run(releaseName, theChart, helmValues)
+		rel, err = client.Run(releaseName, theChart, mergedValues)
 		if err != nil {
 			fmt.Errorf("Failed running Helm command for release %s: %v",
 				releaseName, err)
@@ -248,6 +250,31 @@ func UpgradeChart(kubeInfo *client.KubeInfo, releaseName string, namespace strin
 	}
 
 	return rel, nil
+}
+
+// mergeOverrides - recursively merge the new set of overrides into the existing set of overrides
+func mergeOverrides(currentOverrides map[string]interface{}, newOverrides map[string]interface{}) map[string]interface{} {
+	// Initialize the return value with the current set of overrides
+	mergedOverrides := make(map[string]interface{}, len(currentOverrides))
+	maps.Copy(mergedOverrides, currentOverrides)
+
+	// Merge the new overrides
+	for k, v := range newOverrides {
+		if v, ok := v.(map[string]interface{}); ok {
+			// The value is a map, check if a map entry with the same key already exists in the destination map
+			if bv, ok := mergedOverrides[k]; ok {
+				if bv, ok := bv.(map[string]interface{}); ok {
+					// Recursively merge the sub-map
+					mergedOverrides[k] = mergeOverrides(bv, v)
+					continue
+				}
+			}
+		}
+		// Add the merged override
+		mergedOverrides[k] = v
+	}
+
+	return mergedOverrides
 }
 
 // Template templates a chart using the provided overrides and returns the generated yamls as a string

--- a/pkg/helm/helmcli_test.go
+++ b/pkg/helm/helmcli_test.go
@@ -1,0 +1,74 @@
+// Copyright (c) 2025, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package helm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"sigs.k8s.io/yaml"
+)
+
+// rmBase is the base of a nested merge with a list
+const rmBase = `
+name: base
+host:
+  ip: 1.2.3.4
+  name: foo
+platform:
+  vendor: company1
+  os:
+    name: linux
+    patches:
+    - version: 0.5.0
+      date: 01/01/2020
+`
+
+// rmOverlay is the overlay of a nested merge with a list
+const rmOverlay = `
+host:
+  name: bar
+platform:
+  os:
+    patches:
+    - version: 0.6.0
+      date: 02/02/2022
+`
+
+// rmMerged is the result of a nested merge
+const rmMerged = `
+name: base
+host:
+  ip: 1.2.3.4
+  name: bar
+platform:
+  vendor: company1
+  os:
+    name: linux
+    patches:
+    - version: 0.6.0
+      date: 02/02/2022
+`
+
+func TestMergeOverrides(t *testing.T) {
+	// Convert the base set of overrides into a map
+	base := map[string]interface{}{}
+	err := yaml.Unmarshal([]byte(rmBase), &base)
+	assert.NoError(t, err)
+
+	// Covert the overlay set of overrides into a map
+	overlay := map[string]interface{}{}
+	err = yaml.Unmarshal([]byte(rmOverlay), &overlay)
+	assert.NoError(t, err)
+
+	// Do recursive merge
+	err = MergeMaps(base, overlay)
+	assert.NoError(t, err)
+
+	// Compare with the expected result
+	mergedYaml, err := yaml.Marshal(base)
+	assert.NoError(t, err)
+	assert.YAMLEq(t, rmMerged, string(mergedYaml))
+}


### PR DESCRIPTION
Fixed issue where new overrides were replacing existing ones.  The solution was to merge new overrides into existing ones.