### PR TITLE
Install ovirt-csi-driver during cluster start --provider olvm

### DIFF
--- a/pkg/cluster/driver/olvm/apps.go
+++ b/pkg/cluster/driver/olvm/apps.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024, Oracle and/or its affiliates.
+// Copyright (c) 2024, 2025 Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package olvm
@@ -14,6 +14,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+	"net/url"
 	"sigs.k8s.io/yaml"
 )
 
@@ -127,11 +128,18 @@ func (cad *OlvmDriver) getWorkloadClusterApplications(restConfig *rest.Config, k
 		return nil, err
 	}
 
+	// Append /api to ovirt URL
+	parsedURL, err := url.Parse(olvm.OlvmCluster.OVirtAPI.ServerURL)
+	if err != nil {
+		return nil, err
+	}
+	ovirtURL := parsedURL.JoinPath("/api")
+
 	// set the creds needed by the ovirt csi driver
 	credmap := map[string][]byte{
 		csiDriverUsernameKey: []byte(ovirtCreds[credsUsernameKey]),
 		csiDriverPasswordKey: []byte(ovirtCreds[credsPasswordKey]),
-		csiDriverURLKey:      []byte(olvm.OlvmCluster.OVirtAPI.ServerURL),
+		csiDriverURLKey:      []byte(ovirtURL.String()),
 	}
 
 	// create chart overrides

--- a/pkg/cluster/driver/olvm/apps.go
+++ b/pkg/cluster/driver/olvm/apps.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024, 2025 Oracle and/or its affiliates.
+// Copyright (c) 2024, 2025, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package olvm

--- a/pkg/cluster/driver/olvm/apps.go
+++ b/pkg/cluster/driver/olvm/apps.go
@@ -10,7 +10,9 @@ import (
 	"github.com/oracle-cne/ocne/pkg/constants"
 	"github.com/oracle-cne/ocne/pkg/k8s"
 	"github.com/oracle-cne/ocne/pkg/util/oci"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/client-go/applyconfigurations/core/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 )
@@ -87,52 +89,19 @@ func (cad *OlvmDriver) getApplications() ([]install.ApplicationDescription, erro
 
 // getWorkloadClusterApplications gets the applications that need to be installed into the new CAPI cluster
 func (cad *OlvmDriver) getWorkloadClusterApplications(restConfig *rest.Config, kubeClient kubernetes.Interface) ([]install.ApplicationDescription, error) {
-	if !cad.ClusterConfig.Providers.Olvm.InstallCsiDriver {
+	if !cad.ClusterConfig.Providers.Olvm.CSIDriver != nil {
 		return nil, nil
 	}
 
-	compartmentId, err := oci.GetCompartmentId(cad.ClusterConfig.Providers.Oci.Compartment, cad.ClusterConfig.Providers.Oci.Profile)
-	if err != nil {
-		return nil, err
-	}
-
-	authCreds := map[string]interface{}{
-		"auth": map[string]interface{}{
-			"region":                ociConfig.Region,
-			"tenancy":               ociConfig.Tenancy,
-			"user":                  ociConfig.User,
-			"key":                   ociConfig.Key,
-			"passphrase":            ociConfig.Passphrase,
-			"fingerprint":           ociConfig.Fingerprint,
-			"useInstancePrincipals": ociConfig.UseInstancePrincipal,
-		},
-		"compartment": compartmentId,
-		"vcn":         cad.ClusterConfig.Providers.Oci.Vcn,
-		"loadBalancer": map[string]interface{}{
-			"subnet1":                    cad.ClusterConfig.Providers.Oci.LoadBalancer.Subnet1,
-			"subnet2":                    cad.ClusterConfig.Providers.Oci.LoadBalancer.Subnet2,
-			"securityListManagementMode": "None",
-		},
-	}
-	authCredBytes, err := yaml.Marshal(authCreds)
-	if err != nil {
-		return nil, err
-	}
-
-	ociCcmCreds := map[string][]byte{
-		"cloud-provider.yaml": authCredBytes,
-	}
-	ociCsiCreds := map[string][]byte{
-		"config.yaml": authCredBytes,
-	}
+	olvm := &cad.ClusterConfig.Providers.Olvm
 
 	ret := []install.ApplicationDescription{
 		install.ApplicationDescription{
 			PreInstall: func() error {
 
-				secretName := cad.credSecretName()
+				secretName := olvm.CSIDriver.SecretName
 				k8s.DeleteSecret(kubeClient, cad.ClusterConfig.Providers.Olvm.Namespace, secretName)
-				err = k8s.CreateSecret(kubeClient, cad.ClusterConfig.Providers.Olvm.Namespace, &v1.Secret{
+				err = k8s.CreateSecret(kubeClient, cad.ClusterConfig.Providers.Olvm.Namespace, &corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      secretName,
 						Namespace: cad.ClusterConfig.Providers.Olvm.Namespace,

--- a/pkg/cluster/driver/olvm/start.go
+++ b/pkg/cluster/driver/olvm/start.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024, Oracle and/or its affiliates.
+// Copyright (c) 2024, 2025, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package olvm

--- a/pkg/cluster/driver/olvm/start.go
+++ b/pkg/cluster/driver/olvm/start.go
@@ -26,6 +26,12 @@ import (
 	"time"
 )
 
+const (
+	credsUsernameKey = "username"
+	credsPasswordKey = "password"
+	credsScopeKey    = "scope"
+)
+
 // Start creates an OLVM CAPI cluster which includes a set of control plane nodes and worker nodes.
 func (cad *OlvmDriver) Start() (bool, bool, error) {
 	// If there is a need to generate a template, do so.
@@ -308,9 +314,9 @@ func getCreds() (map[string][]byte, error) {
 	}
 
 	return map[string][]byte{
-		"username": []byte(username),
-		"password": []byte(password),
-		"scope":    []byte(scope),
+		credsUsernameKey: []byte(username),
+		credsPasswordKey: []byte(password),
+		credsScopeKey:    []byte(scope),
 	}, nil
 
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -89,6 +89,10 @@ func GetDefaultConfig() (*types.Config, error) {
 				LocalAPIEndpoint: types.OlvmLocalAPIEndpoint{
 					BindPort: 6444,
 				},
+				CSIDriver: types.OvirtCsiDriver{
+					SecretName:    "ovirt-csi-creds",
+					ConfigMapName: "ovirt-csi-ca.crt",
+				},
 			},
 		},
 		PodSubnet:                constants.PodSubnet,

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -90,8 +90,9 @@ func GetDefaultConfig() (*types.Config, error) {
 					BindPort: 6444,
 				},
 				CSIDriver: types.OvirtCsiDriver{
-					SecretName:    "ovirt-csi-creds",
-					ConfigMapName: "ovirt-csi-ca.crt",
+					Namespace:     constants.OvirtCsiNamespace,
+					SecretName:    constants.OvirtCsiSecretName,
+					ConfigMapName: constants.OvirtCsiConfigMapName,
 				},
 			},
 		},

--- a/pkg/config/types/types.go
+++ b/pkg/config/types/types.go
@@ -55,7 +55,7 @@ type OlvmProvider struct {
 	ControlPlaneMachine OlvmMachine          `yaml:"controlPlaneMachine"`
 	WorkerMachine       OlvmMachine          `yaml:"workerMachine"`
 	LocalAPIEndpoint    OlvmLocalAPIEndpoint `yaml:"localAPIEndpoint"`
-	CSIDriver           OvirtCsiDriver       `yaml:"csiDriver"`
+	CSIDriver           OvirtCsiDriver       `yaml:"ovirtCsiDriver"`
 }
 
 type OvirtCsiDriver struct {

--- a/pkg/config/types/types.go
+++ b/pkg/config/types/types.go
@@ -55,6 +55,17 @@ type OlvmProvider struct {
 	ControlPlaneMachine OlvmMachine          `yaml:"controlPlaneMachine"`
 	WorkerMachine       OlvmMachine          `yaml:"workerMachine"`
 	LocalAPIEndpoint    OlvmLocalAPIEndpoint `yaml:"localAPIEndpoint"`
+	CSIDriver           OvirtCsiDriver       `yaml:"csiDriver"`
+}
+
+type OvirtCsiDriver struct {
+	CsiDriverName        string `yaml:"csiDriverName"`
+	CaProvided           bool   `yaml:"caProvidedFake"`
+	CaProvidedPtr        *bool  `yaml:"caProvided,omitempty"`
+	SecretName           string `yaml:"credsSecretName"`
+	ConfigMapName        string `yaml:"caConfigmapName"`
+	NodePluginName       string `yaml:"nodePluginName"`
+	ControllerPluginName string `yaml:"controllerPluginName"`
 }
 
 type OlvmCluster struct {
@@ -470,6 +481,23 @@ func MergeOlvmProvider(def *OlvmProvider, ovr *OlvmProvider) OlvmProvider {
 		ControlPlaneMachine: MergeOlvmMachine(&def.ControlPlaneMachine, &ovr.ControlPlaneMachine),
 		WorkerMachine:       MergeOlvmMachine(&def.WorkerMachine, &ovr.WorkerMachine),
 		LocalAPIEndpoint:    MergeOlvmLocalAPIEndpoint(&def.LocalAPIEndpoint, &ovr.LocalAPIEndpoint),
+		CSIDriver:           MergeOlvmCsiDriver(&def.CSIDriver, &ovr.CSIDriver),
+	}
+}
+
+// MergeOlvmCsiDriver takes two OlvmCsiDrivers and merges them into
+// a third.  The default value for the result comes from the first
+// argument.  If a value is set in the second argument, that value
+// takes precedence.
+func MergeOlvmCsiDriver(def *OvirtCsiDriver, ovr *OvirtCsiDriver) OvirtCsiDriver {
+	return OvirtCsiDriver{
+		CsiDriverName:        ies(def.CsiDriverName, ovr.CsiDriverName),
+		CaProvided:           iebp(def.CaProvidedPtr, ovr.CaProvidedPtr, true),
+		CaProvidedPtr:        iebpp(def.CaProvidedPtr, ovr.CaProvidedPtr),
+		SecretName:           ies(def.SecretName, ovr.SecretName),
+		ConfigMapName:        ies(def.ConfigMapName, ovr.ConfigMapName),
+		NodePluginName:       ies(def.NodePluginName, ovr.NodePluginName),
+		ControllerPluginName: ies(def.ControllerPluginName, ovr.ControllerPluginName),
 	}
 }
 

--- a/pkg/config/types/types.go
+++ b/pkg/config/types/types.go
@@ -66,6 +66,7 @@ type OvirtCsiDriver struct {
 	CsiDriverName        string `yaml:"csiDriverName"`
 	Install              bool   `yaml:"installFake"`
 	InstallPtr           *bool  `yaml:"install,omitempty"`
+	Namespace            string `yaml:"namespace"`
 	NodePluginName       string `yaml:"nodePluginName"`
 	SecretName           string `yaml:"credsSecretName"`
 }
@@ -501,6 +502,7 @@ func MergeOlvmCsiDriver(def *OvirtCsiDriver, ovr *OvirtCsiDriver) OvirtCsiDriver
 		Install:              iebp(def.InstallPtr, ovr.InstallPtr, true),
 		InstallPtr:           iebpp(def.InstallPtr, ovr.InstallPtr),
 		NodePluginName:       ies(def.NodePluginName, ovr.NodePluginName),
+		Namespace:            ies(def.Namespace, ovr.Namespace),
 		SecretName:           ies(def.SecretName, ovr.SecretName),
 	}
 }

--- a/pkg/config/types/types.go
+++ b/pkg/config/types/types.go
@@ -59,13 +59,15 @@ type OlvmProvider struct {
 }
 
 type OvirtCsiDriver struct {
-	CsiDriverName        string `yaml:"csiDriverName"`
 	CaProvided           bool   `yaml:"caProvidedFake"`
 	CaProvidedPtr        *bool  `yaml:"caProvided,omitempty"`
-	SecretName           string `yaml:"credsSecretName"`
 	ConfigMapName        string `yaml:"caConfigmapName"`
-	NodePluginName       string `yaml:"nodePluginName"`
 	ControllerPluginName string `yaml:"controllerPluginName"`
+	CsiDriverName        string `yaml:"csiDriverName"`
+	Install              bool   `yaml:"installFake"`
+	InstallPtr           *bool  `yaml:"install,omitempty"`
+	NodePluginName       string `yaml:"nodePluginName"`
+	SecretName           string `yaml:"credsSecretName"`
 }
 
 type OlvmCluster struct {
@@ -491,13 +493,15 @@ func MergeOlvmProvider(def *OlvmProvider, ovr *OlvmProvider) OlvmProvider {
 // takes precedence.
 func MergeOlvmCsiDriver(def *OvirtCsiDriver, ovr *OvirtCsiDriver) OvirtCsiDriver {
 	return OvirtCsiDriver{
-		CsiDriverName:        ies(def.CsiDriverName, ovr.CsiDriverName),
 		CaProvided:           iebp(def.CaProvidedPtr, ovr.CaProvidedPtr, true),
 		CaProvidedPtr:        iebpp(def.CaProvidedPtr, ovr.CaProvidedPtr),
-		SecretName:           ies(def.SecretName, ovr.SecretName),
 		ConfigMapName:        ies(def.ConfigMapName, ovr.ConfigMapName),
-		NodePluginName:       ies(def.NodePluginName, ovr.NodePluginName),
 		ControllerPluginName: ies(def.ControllerPluginName, ovr.ControllerPluginName),
+		CsiDriverName:        ies(def.CsiDriverName, ovr.CsiDriverName),
+		Install:              iebp(def.InstallPtr, ovr.InstallPtr, true),
+		InstallPtr:           iebpp(def.InstallPtr, ovr.InstallPtr),
+		NodePluginName:       ies(def.NodePluginName, ovr.NodePluginName),
+		SecretName:           ies(def.SecretName, ovr.SecretName),
 	}
 }
 

--- a/pkg/constants/k8s_constants.go
+++ b/pkg/constants/k8s_constants.go
@@ -55,17 +55,17 @@ const (
 	CNIFlannelDaemonSet = "kube-flannel-ds"
 	CNIFlannelImage     = "container-registry.oracle.com/olcne/flannel"
 
-	KubeProxyRelease   = "kube-proxy"
-	KubeProxyNamespace = "kube-system"
-	KubeProxyChart     = "kube-proxy"
-	KubeProxyVersion   = "2.0.0"
-	KubeProxyDaemonSet = "kube-proxy"
-	KubeProxyConfigMap = "kube-proxy"
-	KubeProxyConfigMapConfig = "config.conf"
+	KubeProxyRelease             = "kube-proxy"
+	KubeProxyNamespace           = "kube-system"
+	KubeProxyChart               = "kube-proxy"
+	KubeProxyVersion             = "2.0.0"
+	KubeProxyDaemonSet           = "kube-proxy"
+	KubeProxyConfigMap           = "kube-proxy"
+	KubeProxyConfigMapConfig     = "config.conf"
 	KubeProxyConfigMapKubeconfig = "kubeconfig.conf"
-	KubeProxyImage     = "container-registry.oracle.com/olcne/kube-proxy"
-	KubeProxyTag       = "current"
-	CurrentTag         = "current"
+	KubeProxyImage               = "container-registry.oracle.com/olcne/kube-proxy"
+	KubeProxyTag                 = "current"
+	CurrentTag                   = "current"
 
 	CatalogRelease   = "ocne-catalog"
 	CatalogNamespace = "ocne-system"
@@ -139,6 +139,15 @@ const (
 	OLVMCAPIControlPlaneMemory = "7GB"
 	OLVMCAPIWorkerMemory       = "16GB"
 
+	// oVirt CSI Driver constants
+	OvirtCsiSecretName    = "ovirt-csi-creds"
+	OvirtCsiConfigMapName = "ovirt-csi-ca.crt"
+	OvirtCsiChart         = "ovirt-csi-driver"
+	OvirtCsiRelease       = "ovirt-csi-driver"
+	OvirtCsiNamespace     = "ovirt-csi"
+	OvirtCsiVersion       = ""
+
+	// Misc
 	DefaultPodImage = "container-registry.oracle.com/os/oraclelinux:8"
 	ScriptMountPath = "/ocne-scripts"
 	KubeNamespace   = "kube-system"
@@ -148,6 +157,6 @@ const (
 	KubeletCMName   = "kubelet-config"
 
 	// Kubernetes Gateway API Crds constants
-	KubernetesGatewayAPICrds = "kubernetes-gateway-api-crds"
+	KubernetesGatewayAPICrds        = "kubernetes-gateway-api-crds"
 	KubernetesGatewayAPICrdsVersion = ""
 )

--- a/pkg/util/nestedmap.go
+++ b/pkg/util/nestedmap.go
@@ -9,10 +9,11 @@ import "strings"
 //		"a": map[string]interface{}{
 //		   "b": map[string]interface{}{
 //		       "c": map[string]interface{}
-func EnsureNestedMap(m map[string]interface{}, dotPath string) map[string]interface{} {
+func EnsureNestedMap(mapRoot map[string]interface{}, dotPath string) map[string]interface{} {
 	segs := strings.Split(dotPath, ".")
 	var inner map[string]interface{}
 
+	m := mapRoot
 	for _, seg := range segs {
 		entry := m[seg]
 		if entry == nil {
@@ -21,6 +22,7 @@ func EnsureNestedMap(m map[string]interface{}, dotPath string) map[string]interf
 		} else {
 			inner = entry.(map[string]interface{})
 		}
+		m = inner
 	}
 	return inner
 }

--- a/pkg/util/nestedmap.go
+++ b/pkg/util/nestedmap.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
 package util
 
 import "strings"

--- a/pkg/util/nestedmap.go
+++ b/pkg/util/nestedmap.go
@@ -1,0 +1,26 @@
+package util
+
+import "strings"
+
+// EnsureNestedMap ensures that a nested map exists.  The map path is specified using dot notation.
+// For example "a.b.c" will ensure the following exists.  The inner-most map is returned
+//
+//	map[string]interface{}{
+//		"a": map[string]interface{}{
+//		   "b": map[string]interface{}{
+//		       "c": map[string]interface{}
+func EnsureNestedMap(m map[string]interface{}, dotPath string) map[string]interface{} {
+	segs := strings.Split(dotPath, ".")
+	var inner map[string]interface{}
+
+	for _, seg := range segs {
+		entry := m[seg]
+		if entry == nil {
+			inner = make(map[string]interface{})
+			m[seg] = inner
+		} else {
+			inner = entry.(map[string]interface{})
+		}
+	}
+	return inner
+}


### PR DESCRIPTION
Install ovirt-csi-driver during `cluster start --provider olvm`.   By default the driver is installed, and there is no config required.   The ovirt-csi-driver catalog chart value.yaml has the defaults.  

The following can be overridden.  

```  
olvm:
    ovirtCsiDriver:
      install: true (default)
      caProvided: true
      caConfigmapName: test-cm
      controllerPluginName: test-controller
      csiDriverName: test-csi-driver-2
      namespace: test-csi-ns-2
      nodePluginName: test-node
      credsSecretName: test-secret
```

I installed ocne with standard olvm config, not ovirt-csi-driver overrides:
```
 ocne cluster start --provider olvm --config ~/.ocne/olvm-demo.yaml 
INFO[2025-04-16T17:38:45-04:00] Installing cert-manager into cert-manager: ok 
INFO[2025-04-16T17:38:46-04:00] Installing core-capi into capi-system: ok 
INFO[2025-04-16T17:38:46-04:00] Installing olvm-capi into cluster-api-provider-olvm: ok 
INFO[2025-04-16T17:38:47-04:00] Installing bootstrap-capi into capi-kubeadm-bootstrap-system: ok 
INFO[2025-04-16T17:38:47-04:00] Installing control-plane-capi into capi-kubeadm-control-plane-system: ok 
INFO[2025-04-16T17:38:48-04:00] Waiting for Core Cluster API Controllers: ok 
INFO[2025-04-16T17:38:48-04:00] Waiting for Kubadm Boostrap Cluster API Controllers: ok 
INFO[2025-04-16T17:38:48-04:00] Waiting for Kubadm Control Plane Cluster API Controllers: ok 
INFO[2025-04-16T17:38:48-04:00] Waiting for Olvm Cluster API Controllers: ok 
INFO[2025-04-16T17:38:48-04:00] Applying Cluster API resources               
INFO[2025-04-16T17:38:48-04:00] Waiting for kubeconfig: ok       
INFO[2025-04-16T17:38:48-04:00] Installing applications into workload cluster 
INFO[2025-04-16T17:38:53-04:00] Installing ovirt-csi-driver into ovirt-csi: ok 
INFO[2025-04-16T17:38:54-04:00] Kubernetes cluster was created successfully  
INFO[2025-04-16T17:38:55-04:00] Waiting for the UI to be ready: ok 

Run the following command to create an authentication token to access the UI:
    KUBECONFIG='/Users/pmackin/.kube/kubeconfig.demo' kubectl create token ui -n ocne-system
``


I created a storagedomain, pvc, and testpod and ensure the data was preserved after a pod reboot:
```
ovirt-csi      ovirt-csi-controller-plugin-bffc5966f-kwl2s        5/5     Running   0          32s
ovirt-csi      ovirt-csi-node-plugin-mqlzg                        3/3     Running   0          32s

~/olvm> kk get csidriver
NAME            ATTACHREQUIRED   PODINFOONMOUNT   STORAGECAPACITY   TOKENREQUESTS   REQUIRESREPUBLISH   MODES        AGE
csi.ovirt.org   true             false            false             <unset>         false               Persistent   37s

~/olvm> kk get storageclass
NAME               PROVISIONER     RECLAIMPOLICY   VOLUMEBINDINGMODE   ALLOWVOLUMEEXPANSION   AGE
oblock (default)   csi.ovirt.org   Delete          Immediate           false                  5h39m

~/olvm> kk apply -f pvc.yaml 
persistentvolumeclaim/1g-ovirt-disk created

~/olvm> kk get pvc -A
NAMESPACE   NAME            STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   VOLUMEATTRIBUTESCLASS   AGE
default     1g-ovirt-disk   Bound    pvc-77d6272a-b24c-40bb-8936-9477edebbce6   1Gi        RWO            oblock         <unset>                 3m47s

~/olvm> kk get pv
NAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM                   STORAGECLASS   VOLUMEATTRIBUTESCLASS   REASON   AGE
pvc-77d6272a-b24c-40bb-8936-9477edebbce6   1Gi        RWO            Delete           Bound    default/1g-ovirt-disk   oblock         <unset>                          0s

~/olvm> kk apply -f testpod.yaml 
pod/test-csi created

~/olvm> kk exec -it test-csi bash
kubectl exec [POD] [COMMAND] is DEPRECATED and will be removed in a future version. Use kubectl exec [POD] -- [COMMAND] instead.
[root@test-csi /]# ls /paul
lost+found

[root@test-csi /]# ls /bin > /paul/bin.txt
[root@test-csi /]# ls /paul
bin.txt  lost+found

[root@test-csi /]# exit
exit

~/olvm> kk delete pod --force test-csi
Warning: Immediate deletion does not wait for confirmation that the running resource has been terminated. The resource may continue to run on the cluster indefinitely.
pod "test-csi" force deleted

~/olvm> kk get pod
No resources found in default namespace.

~/olvm> kk apply -f testpod.yaml 
pod/test-csi created

~/olvm> kk exec -it test-csi bash
kubectl exec [POD] [COMMAND] is DEPRECATED and will be removed in a future version. Use kubectl exec [POD] -- [COMMAND] instead.
[root@test-csi /]# ls /paul
bin.txt  lost+found
[root@test-csi /]# more /paul/bin.txt 
[
alias
arch
awk
b2sum
base32
...
```

I tested this with the defaults, and also tested the overrides.  You can see the helm overrides below.  I checked the pods and csidriver to ensure they were used:

```
hh get values  -n test-csi-ns-2 ovirt-csi-driver 
USER-SUPPLIED VALUES:
csiController:
  ovirtController:
    name: test-controller
csiNode:
  ovirtNode:
    name: test-node
driver:
  name: test-csi-driver-2
ovirt:
  caConfigMapName: test-cm
  caProvided: true
  secretName: test-secret
```

Here is part of the node pod:
```
 kk get pods  -n test-csi-ns-2 
NAME                               READY   STATUS    RESTARTS   AGE
test-controller-57b7d5f479-s8vp9   5/5     Running   0          14m
test-node-prqm2                    3/3     Running   0          14m

...
        env:
        - name: OVIRT_URL
          valueFrom:
            secretKeyRef:
              key: ovirt_url
              name: test-secret
        - name: OVIRT_USERNAME
          valueFrom:
            secretKeyRef:
              key: ovirt_username
              name: test-secret
        - name: OVIRT_PASSWORD
          valueFrom:
            secretKeyRef:
              key: ovirt_password
              name: test-secret

        - name: OVIRT_CAFILE
          value: "/tmp/config/ovirt-engine-ca.pem"
        - name: OVIRT_CA_BUNDLE
          valueFrom:
            configMapKeyRef:
              key: ca.crt
              name: test-cm

```

Here is csidriver
```
kk get csidriver
NAME                ATTACHREQUIRED   PODINFOONMOUNT   STORAGECAPACITY   TOKENREQUESTS   REQUIRESREPUBLISH   MODES        AGE
test-csi-driver-2   true             false            false             <unset>         false               Persistent   15m
```

