### PR TITLE
Fix update.yaml contents

### DIFF
--- a/pkg/cluster/template/olvm/ignition.go
+++ b/pkg/cluster/template/olvm/ignition.go
@@ -9,6 +9,7 @@ import (
 	"github.com/oracle-cne/ocne/pkg/cluster/ignition"
 	"github.com/oracle-cne/ocne/pkg/config/types"
 	"github.com/oracle-cne/ocne/pkg/constants"
+	"github.com/oracle-cne/ocne/pkg/image"
 	"github.com/oracle-cne/ocne/pkg/util"
 	"strings"
 )
@@ -128,11 +129,18 @@ func getExtraIgnition(config *types.Config, clusterConfig *types.ClusterConfig, 
 	ignition.AddFile(ign, presetFileLib)
 
 	// Update service configuration file
+	ostreeTransport, registry, tag, err := image.ParseOstreeReference(clusterConfig.OsRegistry)
+	if err != nil {
+		return "", err
+	}
+	if tag != "" {
+		return "", fmt.Errorf("osRegistry field cannot have a tag")
+	}
 	updateFile := &ignition.File{
 		Path: ignition.OcneUpdateConfigPath,
 		Mode: 0400,
 		Contents: ignition.FileContents{
-			Source: fmt.Sprintf(ignition.OcneUpdateYamlPattern, clusterConfig.OsRegistry, clusterConfig.OsTag),
+			Source: fmt.Sprintf(ignition.OcneUpdateYamlPattern, registry, clusterConfig.OsTag, ostreeTransport),
 		},
 	}
 	ignition.AddFile(ign, updateFile)


### PR DESCRIPTION
Fix the OLVM ignition config code to correctly load the update.yaml.

Tested new OLVM CAP cluster and examined the update.yaml file

```
 ocne cluster start --provider olvm --config ~/.ocne/olvm-demo.yaml 
INFO[2025-04-18T13:58:50-04:00] Installing cert-manager into cert-manager: ok 
INFO[2025-04-18T13:58:50-04:00] Installing core-capi into capi-system: ok 
INFO[2025-04-18T13:58:51-04:00] Installing olvm-capi into cluster-api-provider-olvm: ok 
INFO[2025-04-18T13:58:51-04:00] Installing bootstrap-capi into capi-kubeadm-bootstrap-system: ok 
INFO[2025-04-18T13:58:52-04:00] Installing control-plane-capi into capi-kubeadm-control-plane-system: ok 
INFO[2025-04-18T13:58:52-04:00] Waiting for Core Cluster API Controllers: ok 
INFO[2025-04-18T13:58:52-04:00] Waiting for Kubadm Boostrap Cluster API Controllers: ok 
INFO[2025-04-18T13:58:52-04:00] Waiting for Kubadm Control Plane Cluster API Controllers: ok 
INFO[2025-04-18T13:58:52-04:00] Waiting for Olvm Cluster API Controllers: ok 
INFO[2025-04-18T13:58:52-04:00] Applying Cluster API resources               
INFO[2025-04-18T13:58:54-04:00] Waiting for kubeconfig: ok       
INFO[2025-04-18T14:01:24-04:00] Waiting for the Kubernetes cluster to be ready: ok 
INFO[2025-04-18T14:01:24-04:00] Installing applications into workload cluster 
INFO[2025-04-18T14:01:29-04:00] Installing ovirt-csi-driver into ovirt-csi: ok 
INFO[2025-04-18T14:01:32-04:00] Installing core-dns into kube-system: ok 
INFO[2025-04-18T14:01:34-04:00] Installing kube-proxy into kube-system: ok 
INFO[2025-04-18T14:01:37-04:00] Installing kubernetes-gateway-api-crds into kube-system: ok 
INFO[2025-04-18T14:01:39-04:00] Installing flannel into kube-flannel: ok 
INFO[2025-04-18T14:01:43-04:00] Installing ui into ocne-system: ok 
INFO[2025-04-18T14:01:45-04:00] Installing ocne-catalog into ocne-system: ok 
INFO[2025-04-18T14:01:46-04:00] Kubernetes cluster was created successfully  
^CFO[2025-04-18T14:03:14-04:00] Waiting for the UI to be ready: waiting... 

```


```
cat /etc/ocne/update.yaml 
registry: container-registry.oracle.com/olcne/ock-ostree
tag: 1.31
transport: ostree-unverified-registry
```