### PR TITLE
Update OLVM deployment name

### DIFF
--- a/pkg/constants/k8s_constants.go
+++ b/pkg/constants/k8s_constants.go
@@ -130,7 +130,7 @@ const (
 	OLVMCAPIOperatorNamespace  = "cluster-api-provider-olvm"
 	OLVMCAPIChart              = "olvm-capi"
 	OLVMCAPIVersion            = ""
-	OLVMCAPIDeployment         = "olvm-capi-operator"
+	OLVMCAPIDeployment         = "olvm-capi-controller-manager"
 	OLVMOVirtCredSecretSuffix  = "ovirt-credentials"
 	OLVMOVirtCAConfigMapSuffix = "ovirt-ca"
 


### PR DESCRIPTION
The OLVM controller was failing to come up because we had recently changed the name.  Use the new name.