### PR TITLE
Disable developer builds by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,9 @@ ifeq ($(DEVELOPER_BUILD),)
 	ifeq ($(findstring release/,$(RELEASE_BRANCH)), release/)
 		DEVELOPER_BUILD=false
 	else
-		DEVELOPER_BUILD=true
+		# Disable all developer builds by default, there is currently no
+		# content on the developer branch of the ocne-catalog repo.
+		DEVELOPER_BUILD=false
 	endif
 endif
 


### PR DESCRIPTION
The build fails if the developer build is enabled and the branch is empty.