### PR TITLE
Fix bug where default secret was not being set correctly.

### DIFF
--- a/pkg/cluster/driver/olvm/start.go
+++ b/pkg/cluster/driver/olvm/start.go
@@ -10,12 +10,12 @@ import (
 	oci2 "github.com/oracle-cne/ocne/pkg/cluster/template/oci"
 	"github.com/oracle-cne/ocne/pkg/commands/application/install"
 	"github.com/oracle-cne/ocne/pkg/config/types"
-	"github.com/oracle-cne/ocne/pkg/constants"
 	"github.com/oracle-cne/ocne/pkg/file"
 	"github.com/oracle-cne/ocne/pkg/k8s"
 	"github.com/oracle-cne/ocne/pkg/k8s/client"
 	"github.com/oracle-cne/ocne/pkg/util"
 	"github.com/oracle-cne/ocne/pkg/util/logutils"
+	"github.com/oracle-cne/ocne/pkg/util/olvmutil"
 	log "github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -322,33 +322,9 @@ func getCreds() (map[string][]byte, error) {
 }
 
 func (cad *OlvmDriver) credSecretNsn() *types.NamespacedName {
-	return CredSecretNsn(cad.ClusterConfig)
+	return olvmutil.CredSecretNsn(cad.ClusterConfig)
 }
 
 func (cad *OlvmDriver) caConfigMapNsn() *types.NamespacedName {
-	return CaConfigMapNsn(cad.ClusterConfig)
-}
-
-func CredSecretNsn(cc *types.ClusterConfig) *types.NamespacedName {
-	defName := fmt.Sprintf("%s-%s", cc.Name, constants.OLVMOVirtCredSecretSuffix)
-	nn := cc.Providers.Olvm.OlvmAPIServer.CredentialsSecret
-	if nn.Name == "" {
-		nn.Name = defName
-	}
-	if nn.Namespace == "" {
-		nn.Namespace = cc.Providers.Olvm.Namespace
-	}
-	return &nn
-}
-
-func CaConfigMapNsn(cc *types.ClusterConfig) *types.NamespacedName {
-	defName := fmt.Sprintf("%s-%s", cc.Name, constants.OLVMOVirtCAConfigMapSuffix)
-	nn := cc.Providers.Olvm.OlvmAPIServer.CAConfigMap
-	if nn.Name == "" {
-		nn.Name = defName
-	}
-	if nn.Namespace == "" {
-		nn.Namespace = cc.Providers.Olvm.Namespace
-	}
-	return &nn
+	return olvmutil.CaConfigMapNsn(cad.ClusterConfig)
 }

--- a/pkg/cluster/template/olvm/capi-olvm.go
+++ b/pkg/cluster/template/olvm/capi-olvm.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/oracle-cne/ocne/pkg/cluster/template"
+	"github.com/oracle-cne/ocne/pkg/util/olvmutil"
 	"github.com/oracle-cne/ocne/pkg/util/strutil"
 	"regexp"
 	"strings"
@@ -51,6 +52,11 @@ func GetOlvmTemplate(config *types.Config, clusterConfig *types.ClusterConfig) (
 		return "", err
 	}
 
+	// Get the default CA and Secret (which require cluster name)
+	olvm := &clusterConfig.Providers.Olvm
+	olvm.OlvmAPIServer.CAConfigMap = *olvmutil.CaConfigMapNsn(clusterConfig)
+	olvm.OlvmAPIServer.CredentialsSecret = *olvmutil.CredSecretNsn(clusterConfig)
+
 	// Get the CIDR blocks
 
 	// Build up the extra ignition structures.  Internal LB for control plane only
@@ -62,7 +68,6 @@ func GetOlvmTemplate(config *types.Config, clusterConfig *types.ClusterConfig) (
 	if err != nil {
 		return "", err
 	}
-	olvm := &clusterConfig.Providers.Olvm
 	return util.TemplateToStringWithFuncs(string(tmplBytes), &olvmData{
 		Config:                    config,
 		ClusterConfig:             clusterConfig,

--- a/pkg/util/olvmutil/olvm_resources.go
+++ b/pkg/util/olvmutil/olvm_resources.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
 package olvmutil
 
 import (

--- a/pkg/util/olvmutil/olvm_resources.go
+++ b/pkg/util/olvmutil/olvm_resources.go
@@ -1,0 +1,31 @@
+package olvmutil
+
+import (
+	"fmt"
+	"github.com/oracle-cne/ocne/pkg/config/types"
+	"github.com/oracle-cne/ocne/pkg/constants"
+)
+
+func CredSecretNsn(cc *types.ClusterConfig) *types.NamespacedName {
+	defName := fmt.Sprintf("%s-%s", cc.Name, constants.OLVMOVirtCredSecretSuffix)
+	nn := cc.Providers.Olvm.OlvmAPIServer.CredentialsSecret
+	if nn.Name == "" {
+		nn.Name = defName
+	}
+	if nn.Namespace == "" {
+		nn.Namespace = cc.Providers.Olvm.Namespace
+	}
+	return &nn
+}
+
+func CaConfigMapNsn(cc *types.ClusterConfig) *types.NamespacedName {
+	defName := fmt.Sprintf("%s-%s", cc.Name, constants.OLVMOVirtCAConfigMapSuffix)
+	nn := cc.Providers.Olvm.OlvmAPIServer.CAConfigMap
+	if nn.Name == "" {
+		nn.Name = defName
+	}
+	if nn.Namespace == "" {
+		nn.Namespace = cc.Providers.Olvm.Namespace
+	}
+	return &nn
+}


### PR DESCRIPTION
Fix bug where default secret was not being set correctly in the ocne client generated CAPI manifests. 

I created a cluster with the default secret as a test.

```
 ocne cluster start  --provider olvm -c ~/.ocne/olvm-paul.yaml 
INFO[2025-05-02T14:35:39-04:00] Installing cert-manager into cert-manager: ok 
INFO[2025-05-02T14:35:40-04:00] Installing core-capi into capi-system: ok 
INFO[2025-05-02T14:35:40-04:00] Installing olvm-capi into cluster-api-provider-olvm: ok 
INFO[2025-05-02T14:35:41-04:00] Installing bootstrap-capi into capi-kubeadm-bootstrap-system: ok 
INFO[2025-05-02T14:35:41-04:00] Installing control-plane-capi into capi-kubeadm-control-plane-system: ok 
INFO[2025-05-02T14:35:42-04:00] Waiting for Core Cluster API Controllers: ok 
INFO[2025-05-02T14:35:42-04:00] Waiting for Kubadm Boostrap Cluster API Controllers: ok 
INFO[2025-05-02T14:35:42-04:00] Waiting for Kubadm Control Plane Cluster API Controllers: ok 
INFO[2025-05-02T14:35:42-04:00] Waiting for Olvm Cluster API Controllers: ok 
INFO[2025-05-02T14:35:42-04:00] Applying Cluster API resources               
INFO[2025-05-02T14:35:44-04:00] Waiting for kubeconfig: ok       
INFO[2025-05-02T14:38:02-04:00] Waiting for the Kubernetes cluster to be ready: ok 
INFO[2025-05-02T14:38:02-04:00] Installing applications into workload cluster 
INFO[2025-05-02T14:38:08-04:00] Installing ovirt-csi-driver into ovirt-csi: ok 
INFO[2025-05-02T14:38:13-04:00] Installing core-dns into kube-system: ok 
INFO[2025-05-02T14:38:16-04:00] Installing kube-proxy into kube-system: ok 
INFO[2025-05-02T14:38:19-04:00] Installing kubernetes-gateway-api-crds into kube-system: ok 
INFO[2025-05-02T14:38:22-04:00] Installing flannel into kube-flannel: ok 
INFO[2025-05-02T14:38:25-04:00] Installing ui into ocne-system: ok 
INFO[2025-05-02T14:38:28-04:00] Installing ocne-catalog into ocne-system: ok 
INFO[2025-05-02T14:38:28-04:00] Kubernetes cluster was created successfully  
^CFO[2025-05-02T14:38:36-04:00] Waiting for the UI to be ready: waiting  . 
```