### PR TITLE
Add boot volume size to the OCI provider config

### DIFF
--- a/doc/manpages/ocne-config.yaml.md
+++ b/doc/manpages/ocne-config.yaml.md
@@ -220,10 +220,12 @@ providers:
     controlPlaneShape:
       shape: VM.Standard.A1.Flex
       ocpus: 2
+      bootVolumeSizeInGBs: 50
     # The shape of compute instances for worker nodes
     workerShape:
       shape: VM.Standard.E4.Flex
       ocpus: 4
+      bootVolumeSizeInGBs: 50
     # Indicates if a cluster is self-managing or not.  If set to
     # true, the cluster will contain all the necessary controllers
     # and resources to manage its own lifecycle.  If not, those

--- a/doc/manpages/ocne-defaults.yaml.md
+++ b/doc/manpages/ocne-defaults.yaml.md
@@ -157,10 +157,12 @@ providers:
     controlPlaneShape:
       shape: VM.Standard.A1.Flex
       ocpus: 2
+      bootVolumeSizeInGBs: 50
     # The shape of compute instances for worker nodes
     workerShape:
       shape: VM.Standard.E4.Flex
       ocpus: 4
+      bootVolumeSizeInGBs: 50
     # Indicates if a cluster is self-managing or not.  If set to
     # true, the cluster will contain all the necessary controllers
     # and resources to manage its own lifecycle.  If not, those

--- a/pkg/cluster/template/templates/capi-oci.yaml
+++ b/pkg/cluster/template/templates/capi-oci.yaml
@@ -491,7 +491,7 @@ spec:
       shape: "{{.ClusterConfig.Providers.Oci.WorkerShape.Shape}}"
       shapeConfig:
         ocpus: "{{.ClusterConfig.Providers.Oci.WorkerShape.Ocpus}}"
-      bootVolumeSizeInGBs: "{{.ClusterConfig.Providers.Oci.ControlPlaneShape.BootVolumeSize}}"
+      bootVolumeSizeInGBs: "{{.ClusterConfig.Providers.Oci.WorkerShape.BootVolumeSize}}"
       metadata:
         ssh_authorized_keys: "{{.ClusterConfig.SshPublicKey}}"
       isPvEncryptionInTransitEnabled: false

--- a/pkg/cluster/template/templates/capi-oci.yaml
+++ b/pkg/cluster/template/templates/capi-oci.yaml
@@ -473,6 +473,7 @@ spec:
       shape: "{{.ClusterConfig.Providers.Oci.ControlPlaneShape.Shape}}"
       shapeConfig:
         ocpus: "{{.ClusterConfig.Providers.Oci.ControlPlaneShape.Ocpus}}"
+      bootVolumeSizeInGBs: "{{.ClusterConfig.Providers.Oci.ControlPlaneShape.BootVolumeSize}}"
       metadata:
         ssh_authorized_keys: "{{.ClusterConfig.SshPublicKey}}"
       isPvEncryptionInTransitEnabled: false
@@ -490,6 +491,7 @@ spec:
       shape: "{{.ClusterConfig.Providers.Oci.WorkerShape.Shape}}"
       shapeConfig:
         ocpus: "{{.ClusterConfig.Providers.Oci.WorkerShape.Ocpus}}"
+      bootVolumeSizeInGBs: "{{.ClusterConfig.Providers.Oci.ControlPlaneShape.BootVolumeSize}}"
       metadata:
         ssh_authorized_keys: "{{.ClusterConfig.SshPublicKey}}"
       isPvEncryptionInTransitEnabled: false

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -72,10 +72,12 @@ func GetDefaultConfig() (*types.Config, error) {
 				ControlPlaneShape: types.OciInstanceShape{
 					Shape: constants.OciVmStandardA1Flex,
 					Ocpus: constants.OciControlPlaneOcpus,
+					BootVolumeSize: constants.OciBootVolumeSize,
 				},
 				WorkerShape: types.OciInstanceShape{
 					Shape: constants.OciVmStandardE4Flex,
 					Ocpus: constants.OciWorkerOcpus,
+					BootVolumeSize: constants.OciBootVolumeSize,
 				},
 			},
 			Olvm: types.OlvmProvider{

--- a/pkg/config/types/types.go
+++ b/pkg/config/types/types.go
@@ -17,6 +17,7 @@ type LibvirtProvider struct {
 type OciInstanceShape struct {
 	Shape string `yaml:"shape"`
 	Ocpus int    `yaml:"ocpus"`
+	BootVolumeSize string `yaml:"bootVolumeInGBs"`
 }
 
 type LoadBalancer struct {
@@ -432,6 +433,7 @@ func MergeOciInstanceShape(def *OciInstanceShape, ovr *OciInstanceShape) OciInst
 	return OciInstanceShape{
 		Shape: ies(def.Shape, ovr.Shape),
 		Ocpus: iei(def.Ocpus, ovr.Ocpus),
+		BootVolumeSize: ies(def.BootVolumeSize, ovr.BootVolumeSize),
 	}
 }
 

--- a/pkg/config/types/types.go
+++ b/pkg/config/types/types.go
@@ -17,7 +17,7 @@ type LibvirtProvider struct {
 type OciInstanceShape struct {
 	Shape string `yaml:"shape"`
 	Ocpus int    `yaml:"ocpus"`
-	BootVolumeSize string `yaml:"bootVolumeInGBs"`
+	BootVolumeSize string `yaml:"bootVolumeSizeInGBs"`
 }
 
 type LoadBalancer struct {

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -48,6 +48,7 @@ const (
 
 	OciControlPlaneOcpus = 2
 	OciWorkerOcpus       = 4
+	OciBootVolumeSize    = "50"
 	OciImageName         = "ock"
 	OciBucket            = "ocne-images"
 


### PR DESCRIPTION
The default disk size of 50Gb is not sufficient for any real workloads.  Asking users to create and edit a template for such a small change is silly.  Expose a configuration option directly.