### PR TITLE
Pick an obscure slirp subnet

### DIFF
--- a/doc/manpages/ocne-config.yaml.md
+++ b/doc/manpages/ocne-config.yaml.md
@@ -177,6 +177,8 @@ providers:
     sshKey: /home/myuser/.ssh/id_rsa.ocne
     # The storage pool to use for images
     storagePool: mypool
+    # The subnet to use for the slirp network interface
+    slirpSubnet: 192.18.255.0/24
     # The virtual network to use for domains
     network: bridge-1
     # Boot volume name

--- a/doc/manpages/ocne-defaults.yaml.md
+++ b/doc/manpages/ocne-defaults.yaml.md
@@ -114,6 +114,8 @@ providers:
     sshKey: /home/myuser/.ssh/id_rsa.ocne
     # The storage pool to use for images
     storagePool: mypool
+    # The subnet to use for the slirp network interface
+    slirpSubnet: 192.18.255.0/24
     # The virtual network to use for domains
     network: bridge-1
     # Boot volume name

--- a/pkg/cluster/driver/libvirt/libvirt.go
+++ b/pkg/cluster/driver/libvirt/libvirt.go
@@ -78,6 +78,7 @@ type Network struct {
 	Network      string
 	Bus          string
 	Slot         string
+	Subnet       string
 	PortForwards []PortForward
 }
 
@@ -512,6 +513,7 @@ func (ld *LibvirtDriver) addNode(role types.NodeRole, num int, join bool, tokenS
 			Slot: fmt.Sprintf("%d", UserSlot),
 		}
 		if ld.Config.LoadBalancer == "" {
+			userNetwork.Subnet = ld.Config.Providers.Libvirt.SlirpSubnet
 			userNetwork.PortForwards = []PortForward{
 				{
 					From:   ld.TunnelPort,

--- a/pkg/cluster/driver/libvirt/templates.go
+++ b/pkg/cluster/driver/libvirt/templates.go
@@ -146,7 +146,7 @@ const (
 {{range $net := .Networks}}
   {{if (eq $net.Type "user")}}
     <qemu:arg value='-netdev'/>
-    <qemu:arg value='user,id=mynet,net=10.0.10.0/24{{range $pf := $net.PortForwards}},hostfwd=tcp:{{$pf.Listen}}:{{$pf.From}}-:{{$pf.To}}{{end}}'/>
+    <qemu:arg value='user,id=mynet,net={{$net.Subnet}}{{range $pf := $net.PortForwards}},hostfwd=tcp:{{$pf.Listen}}:{{$pf.From}}-:{{$pf.To}}{{end}}'/>
     <qemu:arg value='-device'/>
     <qemu:arg value='virtio-net,netdev=mynet,addr=0{{$net.Slot}}.0'/>
   {{end}}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -50,6 +50,7 @@ func GetDefaultConfig() (*types.Config, error) {
 		Providers: types.Providers{
 			Libvirt: types.LibvirtProvider{
 				SessionURI:  constants.SessionURI,
+				SlirpSubnet: constants.SlirpSubnet,
 				StoragePool: constants.StoragePool,
 				Network:     constants.Network,
 				ControlPlaneNode: types.Node{

--- a/pkg/config/types/types.go
+++ b/pkg/config/types/types.go
@@ -12,6 +12,7 @@ type LibvirtProvider struct {
 	WorkerNode                   Node   `yaml:"workerNode"`
 	BootVolumeName               string `yaml:"bootVolumeName"`
 	BootVolumeContainerImagePath string `yaml:"bootVolumeContainerImagePath"`
+	SlirpSubnet                  string `yaml:"slirpSubnet"`
 }
 
 type OciInstanceShape struct {
@@ -417,6 +418,7 @@ func MergeLibvirtProvider(def *LibvirtProvider, ovr *LibvirtProvider) LibvirtPro
 	}
 	return LibvirtProvider{
 		SessionURI:                   ies(def.SessionURI, ovr.SessionURI),
+		SlirpSubnet:                  ies(def.SlirpSubnet, ovr.SlirpSubnet),
 		SshKey:                       ies(def.SshKey, ovr.SshKey),
 		StoragePool:                  ies(def.StoragePool, ovr.StoragePool),
 		Network:                      ies(def.Network, ovr.Network),

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -32,6 +32,7 @@ const (
 	EphemeralNodeStorage         = "30Gi"
 	EphemeralClusterName         = "ocne-ephemeral"
 	EphemeralClusterPreserve     = true
+	SlirpSubnet                  = "192.18.255.0/24"
 
 	// Kubernetes defaults`
 	KubeAPIServerBindPort    = uint16(6443)


### PR DESCRIPTION
Change the subnet for the slirp interface to something obscure, avoiding collisions with common subnets.  Also, make it configurable just in case.  192.18.255.0/24 was chosen because it is at the end of the range of a strange subnet.  See https://en.wikipedia.org/wiki/Reserved_IP_addresses