### PR TITLE
Update CLI OLVM provider to use new IPV6 config changes

### DIFF
--- a/pkg/cluster/template/templates/capi-olvm.yaml
+++ b/pkg/cluster/template/templates/capi-olvm.yaml
@@ -159,13 +159,15 @@ spec:
             {{- end }}
             subnet: "{{.ClusterConfig.Providers.Olvm.ControlPlaneMachine.VirtualMachine.Network.IPV4.Subnet}}"
           {{- end }}
-          {{- if .ClusterConfig.Providers.Olvm.ControlPlaneMachine.VirtualMachine.Network.IPV6.Subnet }}
+          {{- if or .ClusterConfig.Providers.Olvm.ControlPlaneMachine.VirtualMachine.Network.IPV6.IpAddresses .ClusterConfig.Providers.Olvm.ControlPlaneMachine.VirtualMachine.Network.IPV6.AutoConf }}
           ipv6:
+            {{- if .ClusterConfig.Providers.Olvm.ControlPlaneMachine.VirtualMachine.Network.IPV6.IpAddresses }}
             ipAddresses:
             {{- range .ControlPlaneIPV6Addresses }}
             - "{{.}}"
             {{- end }}
-            autoConf: "{{.ClusterConfig.Providers.Olvm.ControlPlaneMachine.VirtualMachine.Network.IPV6.AutoConf}}"
+            {{- end }}
+            autoConf: {{.ClusterConfig.Providers.Olvm.ControlPlaneMachine.VirtualMachine.Network.IPV6.AutoConf}}
           {{- end }}
         cpu:
           architecture: "{{.ClusterConfig.Providers.Olvm.ControlPlaneMachine.VirtualMachine.Cpu.Architecture}}"
@@ -223,13 +225,15 @@ spec:
             {{- end }}
             subnet: "{{.ClusterConfig.Providers.Olvm.WorkerMachine.VirtualMachine.Network.IPV4.Subnet}}"
           {{- end }}
-          {{- if .ClusterConfig.Providers.Olvm.WorkerMachine.VirtualMachine.Network.IPV6.Subnet }}
+          {{- if or .ClusterConfig.Providers.Olvm.WorkerMachine.VirtualMachine.Network.IPV6.IpAddresses .ClusterConfig.Providers.Olvm.WorkerMachine.VirtualMachine.Network.IPV6.AutoConf }}
           ipv6:
+            {{- if .ClusterConfig.Providers.Olvm.WorkerMachine.VirtualMachine.Network.IPV6.IpAddresses }}
             ipAddresses:
             {{- range .WorkerIPV6Addresses }}
               - "{{.}}"
             {{- end }}
-            autoConf: "{{.ClusterConfig.Providers.Olvm.WorkerMachine.VirtualMachine.Network.IPV6.AutoConf}}"
+            {{- end }}
+            autoConf: {{.ClusterConfig.Providers.Olvm.WorkerMachine.VirtualMachine.Network.IPV6.AutoConf}}
           {{- end }}
         cpu:
           architecture: "{{.ClusterConfig.Providers.Olvm.WorkerMachine.VirtualMachine.Cpu.Architecture}}"

--- a/pkg/cluster/template/templates/capi-olvm.yaml
+++ b/pkg/cluster/template/templates/capi-olvm.yaml
@@ -165,7 +165,7 @@ spec:
             {{- range .ControlPlaneIPV6Addresses }}
             - "{{.}}"
             {{- end }}
-            subnet: "{{.ClusterConfig.Providers.Olvm.ControlPlaneMachine.VirtualMachine.Network.IPV6.Subnet}}"
+            autoConf: "{{.ClusterConfig.Providers.Olvm.ControlPlaneMachine.VirtualMachine.Network.IPV6.AutoConf}}"
           {{- end }}
         cpu:
           architecture: "{{.ClusterConfig.Providers.Olvm.ControlPlaneMachine.VirtualMachine.Cpu.Architecture}}"
@@ -229,7 +229,7 @@ spec:
             {{- range .WorkerIPV6Addresses }}
               - "{{.}}"
             {{- end }}
-            subnet: "{{.ClusterConfig.Providers.Olvm.WorkerMachine.VirtualMachine.Network.IPV6.Subnet}}"
+            autoConf: "{{.ClusterConfig.Providers.Olvm.WorkerMachine.VirtualMachine.Network.IPV6.AutoConf}}"
           {{- end }}
         cpu:
           architecture: "{{.ClusterConfig.Providers.Olvm.WorkerMachine.VirtualMachine.Cpu.Architecture}}"

--- a/pkg/config/types/types.go
+++ b/pkg/config/types/types.go
@@ -16,8 +16,8 @@ type LibvirtProvider struct {
 }
 
 type OciInstanceShape struct {
-	Shape string `yaml:"shape"`
-	Ocpus int    `yaml:"ocpus"`
+	Shape          string `yaml:"shape"`
+	Ocpus          int    `yaml:"ocpus"`
 	BootVolumeSize string `yaml:"bootVolumeSizeInGBs"`
 }
 
@@ -122,26 +122,32 @@ type OlvmVirtualMachine struct {
 }
 
 type OlvmMachineCpu struct {
-	Architecture string                `yaml:"architecture"`
-	Topology     OlvmMachineCpuToplogy `yaml:"topology"`
+	Architecture string                 `yaml:"architecture"`
+	Topology     OlvmMachineCpuTopology `yaml:"topology"`
 }
 
-type OlvmMachineCpuToplogy struct {
+type OlvmMachineCpuTopology struct {
 	Cores   int `yaml:"cores"`
 	Sockets int `yaml:"sockets"`
 	Threads int `yaml:"threads"`
 }
 
 type OlvmVirtualMachineNetwork struct {
-	Gateway       string `yaml:"gateway"`
-	Interface     string `yaml:"interface"`
-	InterfaceType string `yaml:"interfaceType"`
-	IPV4          OlvmIP `yaml:"ipv4"`
-	IPV6          OlvmIP `yaml:"ipv6"`
+	Gateway       string   `yaml:"gateway"`
+	Interface     string   `yaml:"interface"`
+	InterfaceType string   `yaml:"interfaceType"`
+	IPV4          OlvmIPV4 `yaml:"ipv4"`
+	IPV6          OlvmIPV6 `yaml:"ipv6"`
 }
 
-type OlvmIP struct {
+type OlvmIPV4 struct {
 	Subnet      string `yaml:"subnet"`
+	IpAddresses string `yaml:"ipAddresses"`
+}
+
+type OlvmIPV6 struct {
+	AutoConf    bool   `yaml:"autoConfFake"`
+	AutoConfPtr *bool  `yaml:"autoConf,omitempty"`
 	IpAddresses string `yaml:"ipAddresses"`
 }
 
@@ -435,8 +441,8 @@ func MergeLibvirtProvider(def *LibvirtProvider, ovr *LibvirtProvider) LibvirtPro
 // takes precendence.
 func MergeOciInstanceShape(def *OciInstanceShape, ovr *OciInstanceShape) OciInstanceShape {
 	return OciInstanceShape{
-		Shape: ies(def.Shape, ovr.Shape),
-		Ocpus: iei(def.Ocpus, ovr.Ocpus),
+		Shape:          ies(def.Shape, ovr.Shape),
+		Ocpus:          iei(def.Ocpus, ovr.Ocpus),
 		BootVolumeSize: ies(def.BootVolumeSize, ovr.BootVolumeSize),
 	}
 }
@@ -620,16 +626,16 @@ func MergeOlvmVirtualMachine(def *OlvmVirtualMachine, ovr *OlvmVirtualMachine) O
 func MergeOlvmMachineCpu(def *OlvmMachineCpu, ovr *OlvmMachineCpu) OlvmMachineCpu {
 	return OlvmMachineCpu{
 		Architecture: ies(def.Architecture, ovr.Architecture),
-		Topology:     MergeOlvmMachineCpuToplogy(&def.Topology, &ovr.Topology),
+		Topology:     MergeOlvmMachineCpuTopology(&def.Topology, &ovr.Topology),
 	}
 }
 
-// MergeOlvmMachineCpuToplogy takes two OlvmMachineCpuToplogies and merges them into
+// MergeOlvmMachineCpuTopology takes two OlvmMachineCpuTopologies and merges them into
 // a third.  The default value for the result comes from the first
 // argument.  If a value is set in the second argument, that value
 // takes precedence.
-func MergeOlvmMachineCpuToplogy(def *OlvmMachineCpuToplogy, ovr *OlvmMachineCpuToplogy) OlvmMachineCpuToplogy {
-	return OlvmMachineCpuToplogy{
+func MergeOlvmMachineCpuTopology(def *OlvmMachineCpuTopology, ovr *OlvmMachineCpuTopology) OlvmMachineCpuTopology {
+	return OlvmMachineCpuTopology{
 		Cores:   iei(def.Cores, ovr.Cores),
 		Sockets: iei(def.Sockets, ovr.Sockets),
 		Threads: iei(def.Threads, ovr.Threads),
@@ -645,18 +651,30 @@ func MergeOlvmVirtualMachineNetwork(def *OlvmVirtualMachineNetwork, ovr *OlvmVir
 		Gateway:       ies(def.Gateway, ovr.Gateway),
 		Interface:     ies(def.Interface, ovr.Interface),
 		InterfaceType: ies(def.InterfaceType, ovr.InterfaceType),
-		IPV4:          MergeOlvmIP(&def.IPV4, &ovr.IPV4),
-		IPV6:          MergeOlvmIP(&def.IPV6, &ovr.IPV6),
+		IPV4:          MergeOlvmIPV4(&def.IPV4, &ovr.IPV4),
+		IPV6:          MergeOlvmIPV6(&def.IPV6, &ovr.IPV6),
 	}
 }
 
-// MergeOlvmIP takes two OlvmIP and merges them into
+// MergeOlvmIPV4 takes two OlvmIPV4 and merges them into
 // a third.  The default value for the result comes from the first
 // argument.  If a value is set in the second argument, that value
 // takes precedence.
-func MergeOlvmIP(def *OlvmIP, ovr *OlvmIP) OlvmIP {
-	return OlvmIP{
+func MergeOlvmIPV4(def *OlvmIPV4, ovr *OlvmIPV4) OlvmIPV4 {
+	return OlvmIPV4{
 		Subnet:      ies(def.Subnet, ovr.Subnet),
+		IpAddresses: ies(def.IpAddresses, ovr.IpAddresses),
+	}
+}
+
+// MergeOlvmIPV6 takes two OlvmIPV6 and merges them into
+// a third.  The default value for the result comes from the first
+// argument.  If a value is set in the second argument, that value
+// takes precedence.
+func MergeOlvmIPV6(def *OlvmIPV6, ovr *OlvmIPV6) OlvmIPV6 {
+	return OlvmIPV6{
+		AutoConf:    iebp(def.AutoConfPtr, ovr.AutoConfPtr, false),
+		AutoConfPtr: iebpp(def.AutoConfPtr, ovr.AutoConfPtr),
 		IpAddresses: ies(def.IpAddresses, ovr.IpAddresses),
 	}
 }


### PR DESCRIPTION
Update CLI OLVM provider to use new IPV6 config changes.

1. Add AutoConf
2. Remove IPV6 Subnet field

**Tested cluster start with both IPV6 and IPV4**
```
ocne cluster start  --provider olvm -c ~/.ocne/olvm-gz.yaml
INFO[2025-05-12T17:54:11-04:00] Installing cert-manager into cert-manager: ok 
INFO[2025-05-12T17:54:12-04:00] Installing core-capi into capi-system: ok 
INFO[2025-05-12T17:54:12-04:00] Installing olvm-capi into cluster-api-provider-olvm: ok 
INFO[2025-05-12T17:54:13-04:00] Installing bootstrap-capi into capi-kubeadm-bootstrap-system: ok 
INFO[2025-05-12T17:54:13-04:00] Installing control-plane-capi into capi-kubeadm-control-plane-system: ok 
INFO[2025-05-12T17:54:14-04:00] Waiting for Core Cluster API Controllers: ok 
INFO[2025-05-12T17:54:14-04:00] Waiting for Kubadm Boostrap Cluster API Controllers: ok 
INFO[2025-05-12T17:54:14-04:00] Waiting for Kubadm Control Plane Cluster API Controllers: ok 
INFO[2025-05-12T17:54:14-04:00] Applying Cluster API resources               
INFO[2025-05-12T17:54:16-04:00] Waiting for kubeconfig: ok       
INFO[2025-05-12T17:56:51-04:00] Waiting for the Kubernetes cluster to be ready: ok 
INFO[2025-05-12T17:56:51-04:00] Installing applications into workload cluster 
INFO[2025-05-12T17:56:59-04:00] Installing ovirt-csi-driver into ovirt-csi: ok 
INFO[2025-05-12T17:57:03-04:00] Installing core-dns into kube-system: ok 
INFO[2025-05-12T17:57:06-04:00] Installing kube-proxy into kube-system: ok 
INFO[2025-05-12T17:57:10-04:00] Installing kubernetes-gateway-api-crds into kube-system: ok 
INFO[2025-05-12T17:57:13-04:00] Installing flannel into kube-flannel: ok 
INFO[2025-05-12T17:57:16-04:00] Installing ui into ocne-system: ok 
INFO[2025-05-12T17:57:19-04:00] Installing ocne-catalog into ocne-system: ok 
INFO[2025-05-12T17:57:19-04:00] Kubernetes cluster was created successfully  
INFO[2025-05-12T18:00:11-04:00] Waiting for the UI to be ready: ok 
```
**Tested the following fake config and verified the template was correct**
```
name: paul
workerNodes: 1
controlPlaneNodes: 1
podSubnet: 10.244.0.0/16, 2001:0db8:0000:0000:0000:0000:0000:0000/64
serviceSubnet: 10.96.0.0/12, 4001:0db8:0000:0000:0000:0000:0000:0000/64
virtualIp: 1.2.3.160
provider: olvm
providers:
  olvm:
    namespace: olvm
    olvmDatacenterName: Default
    olvmOvirtAPIServer:
      serverURL: https://example.com/ovirt-engine
      serverCAPath: "~/olvm/paul/ca.crt"
      credentialsSecret:
        name: olvm-creds
        namespace: FakeNSCreds
      caConfigMap:
        name: olvm-ca
        namespace: FakeNsCA
      insecureSkipTLSVerify: true
    olvmOCK:
      storageDomainName: olvm-data
      diskName: paul-ock-1.31
      diskSize: 16GB
    controlPlaneMachine:
      olvmOvirtClusterName: Default
      vmTemplateName: paul-ock-1.31
      olvmNetwork:
        networkName: kvm-vlan
        vnicName: nic-1
        vnicProfileName: kvm-vlan
      virtualMachine:
        memory: "7GB"
        cpu:
          architecture: x86_66
          topology:
            cores: 7
            sockets: 9
            threads: 2
        network:
          gateway: 1.2.3.1
          interface: enp1s0
          interfaceType: virtio
          ipv4:
            subnet: 1.2.3.160/24
            ipAddresses: 1.2.3.161/30, 1.2.3.196, 1.2.3.200-1.2.3.220
          ipv6:
            autoConf: false
            ipAddresses: 3001:0db8:0000:0000:0000:0000:0000:1111/60, 3001:0db8:0000:0000:0000:0000:0000:1111/62
          networkName: kvm-vlan
    workerMachine:
      olvmOvirtClusterName: Default
      vmTemplateName: paul-ock-1.31
      olvmNetwork:
        networkName: kvm-vlan
        vnicName: nic-1
        vnicProfileName: kvm-vlan
      virtualMachine:
        memory: "16GB"
        cpu:
          architecture: x86_67
          topology:
            cores: 6
            sockets: 8
            threads: 3
        network:
          gateway: 1.2.3.1
          interface: enp1s0
          interfaceType: virtio
          ipv6:
            autoConf: true
          networkName: kvm-vlan


```

