### PR TITLE
Fix various issues with cluster join

### DIFF
--- a/pkg/commands/cluster/join/join.go
+++ b/pkg/commands/cluster/join/join.go
@@ -151,7 +151,7 @@ func getControlPlaneEndpoint(kubeClient kubernetes.Interface) (string, error) {
 	}
 	hostIface, ok := config["controlPlaneEndpoint"]
 	if !ok {
-		return "", fmt.Errorf("Kubeadm configuration does have a controlPlaneEndpoint")
+		return "", fmt.Errorf("Kubeadm configuration does not have a controlPlaneEndpoint")
 	}
 
 	host, ok := hostIface.(string)

--- a/pkg/commands/cluster/join/join.go
+++ b/pkg/commands/cluster/join/join.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -14,7 +15,6 @@ import (
 	"strings"
 
 	log "github.com/sirupsen/logrus"
-	"gopkg.in/yaml.v3"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -73,13 +73,13 @@ func joinNodeToCluster(options *JoinOptions) error {
 		return err
 	}
 
-	_, destKubeClient, err := client.GetKubeClient(options.DestKubeConfigPath)
+	destRestConfig, destKubeClient, err := client.GetKubeClient(options.DestKubeConfigPath)
 	if err != nil {
 		return err
 	}
 
 	// get the control plane endpoint from the destination cluster
-	cpEndpoint, err := getControlPlaneEndpoint(destKubeClient)
+	cpEndpoint, err := getControlPlaneEndpoint(destRestConfig)
 	if err != nil {
 		return err
 	}
@@ -139,19 +139,12 @@ func joinNodeToCluster(options *JoinOptions) error {
 }
 
 // getControlPlaneEndpoint fetches the control plane endpoint from the kubeadm-config ConfigMap.
-func getControlPlaneEndpoint(kubeClient kubernetes.Interface) (string, error) {
-	cm, err := kubeClient.CoreV1().ConfigMaps(metav1.NamespaceSystem).Get(context.TODO(), kubeadmconst.KubeadmConfigConfigMap, metav1.GetOptions{})
+func getControlPlaneEndpoint(restConfig *rest.Config) (string, error) {
+	u, err := url.Parse(restConfig.Host)
 	if err != nil {
 		return "", err
 	}
-
-	ccYaml := cm.Data["ClusterConfiguration"]
-	cc := &ignition.ClusterConfig{}
-	if err = yaml.Unmarshal([]byte(ccYaml), cc); err != nil {
-		return "", err
-	}
-
-	return cc.ControlPlaneEndpoint, nil
+	return u.Host, nil
 }
 
 // updateNode creates a temporary pod and runs a script to reconfigure the node so that it joins the destination cluster.
@@ -283,8 +276,8 @@ func configureHA(options *JoinOptions, cj *ignition.ClusterJoin) ([]string, erro
 		bindPortAlt = cj.KubeAPIBindPortAlt
 	}
 
-	// get the network interface and optional proxy config from the node we are migrating
-	bootstrapConfFile, proxyConfFile, err := getFilesFromMigratingNode(options, tmpDir)
+	// get the network interface from node we are migrating
+	bootstrapConfFile, err := getFilesFromMigratingNode(options, tmpDir)
 	if err != nil {
 		return nil, err
 	}
@@ -293,13 +286,9 @@ func configureHA(options *JoinOptions, cj *ignition.ClusterJoin) ([]string, erro
 	if err != nil {
 		return nil, err
 	}
-	proxy, err := parseProxyConfig(proxyConfFile)
-	if err != nil {
-		return nil, err
-	}
 
 	// we have collected all the data, now generate the keepalive files and copy them to the node we are migrating
-	return copyHAFilesToNode(options, bindPort, bindPortAlt, vip, proxy, netInterface)
+	return copyHAFilesToNode(options, bindPort, bindPortAlt, vip, netInterface)
 }
 
 // getFilesFromDestCluster copies files from a control plane node on the destination cluster.
@@ -320,10 +309,10 @@ func getFilesFromDestCluster(options *JoinOptions, tmpDir string) (string, error
 	}
 
 	cc, err := startAdminPod(restConfig, kubeClient, options.DestKubeConfigPath, nodes.Items[0].Name)
-	defer k8s.DeletePod(kubeClient, constants.OCNESystemNamespace, cc.PodName)
 	if err != nil {
 		return "", err
 	}
+	defer k8s.DeletePod(kubeClient, constants.OCNESystemNamespace, cc.PodName)
 
 	localTemplatePath := filepath.Join(tmpDir, filepath.Base(ignition.KeepAlivedConfigTemplatePath))
 	cc.FilePaths = append(cc.FilePaths, kubectl.FilePath{RemotePath: "/hostroot" + ignition.KeepAlivedConfigTemplatePath, LocalPath: localTemplatePath})
@@ -336,31 +325,28 @@ func getFilesFromDestCluster(options *JoinOptions, tmpDir string) (string, error
 }
 
 // getFilesFromMigratingNode copies files from the node we are migrating.
-func getFilesFromMigratingNode(options *JoinOptions, tmpDir string) (string, string, error) {
+func getFilesFromMigratingNode(options *JoinOptions, tmpDir string) (string, error) {
 	restConfig, kubeClient, err := client.GetKubeClient(options.KubeConfigPath)
 	if err != nil {
-		return "", "", err
+		return "", err
 	}
 
 	cc, err := startAdminPod(restConfig, kubeClient, options.KubeConfigPath, options.Node)
-	defer k8s.DeletePod(kubeClient, constants.OCNESystemNamespace, cc.PodName)
 	if err != nil {
-		return "", "", err
+		return "", err
 	}
+	defer k8s.DeletePod(kubeClient, constants.OCNESystemNamespace, cc.PodName)
 
 	const bootstrapConfPath = "/etc/systemd/system/ocne.service.d/bootstrap.conf"
-	const proxyConfPath = "/etc/systemd/system/ocne-update.service.d/proxy.conf"
 
 	localBootstrapConfPath := filepath.Join(tmpDir, filepath.Base(bootstrapConfPath))
 	cc.FilePaths = append(cc.FilePaths, kubectl.FilePath{RemotePath: "/hostroot" + bootstrapConfPath, LocalPath: localBootstrapConfPath})
-	localProxyConfPath := filepath.Join(tmpDir, filepath.Base(proxyConfPath))
-	cc.FilePaths = append(cc.FilePaths, kubectl.FilePath{RemotePath: "/hostroot" + proxyConfPath, LocalPath: localProxyConfPath})
 
 	if err = kubectl.CopyFilesFromPod(cc, "Copying files from migrating node"); err != nil {
-		return "", "", err
+		return "", err
 	}
 
-	return localBootstrapConfPath, localProxyConfPath, nil
+	return localBootstrapConfPath, nil
 }
 
 // parseVirtualIP parses the virtual IP from the keepalived template.
@@ -399,46 +385,16 @@ func parseNetworkInterface(file string) (string, error) {
 	return match[1], nil
 }
 
-// parseProxyConfig parses the optional proxy configuration (taken from optional proxy configuration
-// on the ocne-update service).
-func parseProxyConfig(file string) (*types.Proxy, error) {
-	b, err := os.ReadFile(file)
-	if err != nil {
-		// if the file does not exist, then the user has not configured a proxy
-		if os.IsNotExist(err) {
-			return nil, nil
-		}
-		return nil, err
-	}
-
-	proxy := &types.Proxy{}
-
-	regex := regexp.MustCompile(`HTTPS_PROXY=(.*)\s*$`)
-	match := regex.FindStringSubmatch(string(b))
-	if len(match) > 1 {
-		proxy.HttpsProxy = match[1]
-	}
-
-	regex = regexp.MustCompile(`HTTP_PROXY=(.*)\s*$`)
-	match = regex.FindStringSubmatch(string(b))
-	if len(match) > 1 {
-		proxy.HttpProxy = match[1]
-	}
-
-	regex = regexp.MustCompile(`no_proxy=(.*)\s*$`)
-	match = regex.FindStringSubmatch(string(b))
-	if len(match) > 1 {
-		proxy.NoProxy = match[1]
-	}
-	proxy.NoProxy = match[1]
-
-	return proxy, nil
-}
-
 // startAdminPod starts an admin pod on a node so we can copy files.
 func startAdminPod(restConfig *rest.Config, kubeClient kubernetes.Interface, kubeConfigPath string, nodeName string) (*kubectl.CopyConfig, error) {
 	// first delete the pod in case there's an old one running
-	k8s.DeletePod(kubeClient, constants.OCNESystemNamespace, copyPodPrefix+"-"+nodeName)
+	k8s.DeleteAdminPod(kubeClient, nodeName, constants.OCNESystemNamespace, copyPodPrefix)
+
+
+	err := k8s.CreateNamespaceIfNotExists(kubeClient, constants.OCNESystemNamespace)
+	if err != nil {
+		return nil, err
+	}
 
 	pod, err := k8s.StartAdminPodOnNode(kubeClient, nodeName, constants.OCNESystemNamespace, copyPodPrefix, false)
 	if err != nil {
@@ -454,7 +410,7 @@ func startAdminPod(restConfig *rest.Config, kubeClient kubernetes.Interface, kub
 }
 
 // copyHAFilesToNode copies keepalived and nginx configuration files to the migrating node.
-func copyHAFilesToNode(options *JoinOptions, bindPort uint16, altPort uint16, virtualIP string, proxy *types.Proxy, netInterface string) ([]string, error) {
+func copyHAFilesToNode(options *JoinOptions, bindPort uint16, altPort uint16, virtualIP string, netInterface string) ([]string, error) {
 	restConfig, kubeClient, err := client.GetKubeClient(options.KubeConfigPath)
 	if err != nil {
 		return nil, err
@@ -467,7 +423,7 @@ func copyHAFilesToNode(options *JoinOptions, bindPort uint16, altPort uint16, vi
 	}
 
 	// generate all of the files and systemd units needed to configure HA
-	assets, err := ignition.GenerateAssetsForVirtualIp(bindPort, altPort, virtualIP, proxy, netInterface)
+	assets, err := ignition.GenerateAssetsForVirtualIp(bindPort, altPort, virtualIP, nil, netInterface)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/commands/cluster/join/scripts.go
+++ b/pkg/commands/cluster/join/scripts.go
@@ -13,8 +13,14 @@ chroot /hostroot mv /etc/kubernetes/kubeadm.conf /etc/kubernetes/kubeadm.conf.ba
 chroot /hostroot bash -c "echo \"$JOIN_CONFIG\" > /etc/kubernetes/kubeadm.conf"
 chroot /hostroot sed -i '/Environment=ACTION=/c\Environment=ACTION=join' /etc/systemd/system/ocne.service.d/bootstrap.conf
 chroot /hostroot systemctl daemon-reload
+chroot /hostroot chown keepalived_script:keepalived_script /etc/keepalived/peers /etc/keepalived/keepalived.conf /etc/keepalived/log /etc/ocne/nginx/servers /etc/ocne/nginx/servers /etc/ocne/nginx/nginx.conf || true
 chroot /hostroot bash -c 'for svc in $ENABLE_SERVICES; do systemctl enable $svc --now; done'
 chroot /hostroot touch /etc/ocne/reset-kubeadm
 chroot /hostroot systemctl restart ocne
+`
+
+	// Get the network interface that hosts the route for an IP address
+	defaultRouteScript = `#! /bin/bash
+ip -o route get %s | cut -d' ' -f3
 `
 )

--- a/pkg/k8s/tokens.go
+++ b/pkg/k8s/tokens.go
@@ -160,11 +160,16 @@ func UploadCertificates(kubeconfigPath string, key string) error {
 
 	nodeName := nodes.Items[0].ObjectMeta.Name
 
-	pod, err := StartAdminPodOnNode(client, nodeName, constants.OCNESystemNamespace, "exec", false)
-	defer DeletePod(client, pod.ObjectMeta.Namespace, pod.ObjectMeta.Name)
+	err = CreateNamespaceIfNotExists(client, constants.OCNESystemNamespace)
 	if err != nil {
 		return err
 	}
+
+	pod, err := StartAdminPodOnNode(client, nodeName, constants.OCNESystemNamespace, "exec", false)
+	if err != nil {
+		return err
+	}
+	defer DeletePod(client, pod.ObjectMeta.Namespace, pod.ObjectMeta.Name)
 
 	ignore := []string{
 		"could not fetch a Kubernetes version",


### PR DESCRIPTION
A demo:
```
$ cat start.sh 
#! /bin/bash
#
# Copyright (c) 2024, Oracle and/or its affiliates.
# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.

SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
source "$SCRIPT_DIR/env.sh"

set -x

PUBKEY="$(cat ~/.ssh/id_rsa.pub)"

create_node() {
	NAME="$1"

	create_domain "$NAME" "${NAME}.ign"
}

join_node() {
	NAME="$1"
	IP=$($SCRIPT_DIR/get-domain-ip.sh "${NAME}")

	ssh -o StrictHostKeyChecking=no sshuser@$IP sudo cat /etc/kubernetes/admin.conf > kubeconfig.node
	ocne cluster join -k kubeconfig.node --node "${NAME}" --destination "$KUBECONFIG" --log-level debug
}

# Generate the intial ignition
create_node "${CLUSTER_NAME}-control-plane-1"
create_node "${CLUSTER_NAME}-control-plane-2"
create_node "${CLUSTER_NAME}-control-plane-3"
create_node "${CLUSTER_NAME}-worker-1"
create_node "${CLUSTER_NAME}-worker-2"
create_node "${CLUSTER_NAME}-worker-3"

# Sleep for a bit to let networking shake out
sleep 120

CP1IP=$($SCRIPT_DIR/get-domain-ip.sh ${CLUSTER_NAME}-control-plane-1)
export KUBECONFIG=kubeconfig.cp1
ssh -o StrictHostKeyChecking=no sshuser@$CP1IP sudo cat /etc/kubernetes/admin.conf > $KUBECONFIG

# Install the default applications
ocne application install --namespace kube-flannel --name flannel --release flannel --catalog embedded
ocne cluster start --provider none --kubeconfig "$KUBECONFIG" --auto-start-ui=false

# join some worker nodes
join_node "${CLUSTER_NAME}-worker-1"
join_node "${CLUSTER_NAME}-worker-2"
join_node "${CLUSTER_NAME}-worker-3"

sleep 30
kubectl get node

# Give the control plane nodes a bit to shake out
# so they aren't stepping on each other.
join_node "${CLUSTER_NAME}-control-plane-2"
sleep 10

join_node "${CLUSTER_NAME}-control-plane-3"

sleep 30
kubectl get node


$ CLUSTER_NAME=join sh start.sh 
+ create_node join-control-plane-1
+ NAME=join-control-plane-1
+ create_domain join-control-plane-1 join-control-plane-1.ign
+ NAME=join-control-plane-1
+ IGN=join-control-plane-1.ign
+ DOM_VOL=join-control-plane-1.qcow2
+ IGN_VOL=/var/lib/libvirt/images/join-control-plane-1.ign
+ sudo qemu-img create -f qcow2 -F qcow2 -b /var/lib/libvirt/images/boot.qcow2-1.30 /var/lib/libvirt/images/join-control-plane-1.qcow2 30G
Formatting '/var/lib/libvirt/images/join-control-plane-1.qcow2', fmt=qcow2 cluster_size=65536 extended_l2=off compression_type=zlib size=32212254720 backing_file=/var/lib/libvirt/images/boot.qcow2-1.30 backing_fmt=qcow2 lazy_refcounts=off refcount_bits=16
+ sudo cp join-control-plane-1.ign /var/lib/libvirt/images/join-control-plane-1.ign
+ sudo virsh pool-refresh images
Pool images refreshed

+ cat
++ uname -m
+ sudo virsh define join-control-plane-1.xml
Domain 'join-control-plane-1' defined from join-control-plane-1.xml

+ sudo virsh start join-control-plane-1
Domain 'join-control-plane-1' started

+ create_node join-control-plane-2
+ NAME=join-control-plane-2
+ create_domain join-control-plane-2 join-control-plane-2.ign
+ NAME=join-control-plane-2
+ IGN=join-control-plane-2.ign
+ DOM_VOL=join-control-plane-2.qcow2
+ IGN_VOL=/var/lib/libvirt/images/join-control-plane-2.ign
+ sudo qemu-img create -f qcow2 -F qcow2 -b /var/lib/libvirt/images/boot.qcow2-1.30 /var/lib/libvirt/images/join-control-plane-2.qcow2 30G
Formatting '/var/lib/libvirt/images/join-control-plane-2.qcow2', fmt=qcow2 cluster_size=65536 extended_l2=off compression_type=zlib size=32212254720 backing_file=/var/lib/libvirt/images/boot.qcow2-1.30 backing_fmt=qcow2 lazy_refcounts=off refcount_bits=16
+ sudo cp join-control-plane-2.ign /var/lib/libvirt/images/join-control-plane-2.ign
+ sudo virsh pool-refresh images
Pool images refreshed

+ cat
++ uname -m
+ sudo virsh define join-control-plane-2.xml
Domain 'join-control-plane-2' defined from join-control-plane-2.xml

+ sudo virsh start join-control-plane-2
Domain 'join-control-plane-2' started

+ create_node join-control-plane-3
+ NAME=join-control-plane-3
+ create_domain join-control-plane-3 join-control-plane-3.ign
+ NAME=join-control-plane-3
+ IGN=join-control-plane-3.ign
+ DOM_VOL=join-control-plane-3.qcow2
+ IGN_VOL=/var/lib/libvirt/images/join-control-plane-3.ign
+ sudo qemu-img create -f qcow2 -F qcow2 -b /var/lib/libvirt/images/boot.qcow2-1.30 /var/lib/libvirt/images/join-control-plane-3.qcow2 30G
Formatting '/var/lib/libvirt/images/join-control-plane-3.qcow2', fmt=qcow2 cluster_size=65536 extended_l2=off compression_type=zlib size=32212254720 backing_file=/var/lib/libvirt/images/boot.qcow2-1.30 backing_fmt=qcow2 lazy_refcounts=off refcount_bits=16
+ sudo cp join-control-plane-3.ign /var/lib/libvirt/images/join-control-plane-3.ign
+ sudo virsh pool-refresh images
Pool images refreshed

+ cat
++ uname -m
+ sudo virsh define join-control-plane-3.xml
Domain 'join-control-plane-3' defined from join-control-plane-3.xml

+ sudo virsh start join-control-plane-3
Domain 'join-control-plane-3' started

+ create_node join-worker-1
+ NAME=join-worker-1
+ create_domain join-worker-1 join-worker-1.ign
+ NAME=join-worker-1
+ IGN=join-worker-1.ign
+ DOM_VOL=join-worker-1.qcow2
+ IGN_VOL=/var/lib/libvirt/images/join-worker-1.ign
+ sudo qemu-img create -f qcow2 -F qcow2 -b /var/lib/libvirt/images/boot.qcow2-1.30 /var/lib/libvirt/images/join-worker-1.qcow2 30G
Formatting '/var/lib/libvirt/images/join-worker-1.qcow2', fmt=qcow2 cluster_size=65536 extended_l2=off compression_type=zlib size=32212254720 backing_file=/var/lib/libvirt/images/boot.qcow2-1.30 backing_fmt=qcow2 lazy_refcounts=off refcount_bits=16
+ sudo cp join-worker-1.ign /var/lib/libvirt/images/join-worker-1.ign
+ sudo virsh pool-refresh images
Pool images refreshed

+ cat
++ uname -m
+ sudo virsh define join-worker-1.xml
Domain 'join-worker-1' defined from join-worker-1.xml

+ sudo virsh start join-worker-1
Domain 'join-worker-1' started

+ create_node join-worker-2
+ NAME=join-worker-2
+ create_domain join-worker-2 join-worker-2.ign
+ NAME=join-worker-2
+ IGN=join-worker-2.ign
+ DOM_VOL=join-worker-2.qcow2
+ IGN_VOL=/var/lib/libvirt/images/join-worker-2.ign
+ sudo qemu-img create -f qcow2 -F qcow2 -b /var/lib/libvirt/images/boot.qcow2-1.30 /var/lib/libvirt/images/join-worker-2.qcow2 30G
Formatting '/var/lib/libvirt/images/join-worker-2.qcow2', fmt=qcow2 cluster_size=65536 extended_l2=off compression_type=zlib size=32212254720 backing_file=/var/lib/libvirt/images/boot.qcow2-1.30 backing_fmt=qcow2 lazy_refcounts=off refcount_bits=16
+ sudo cp join-worker-2.ign /var/lib/libvirt/images/join-worker-2.ign
+ sudo virsh pool-refresh images
Pool images refreshed

+ cat
++ uname -m
+ sudo virsh define join-worker-2.xml
Domain 'join-worker-2' defined from join-worker-2.xml

+ sudo virsh start join-worker-2
Domain 'join-worker-2' started

+ create_node join-worker-3
+ NAME=join-worker-3
+ create_domain join-worker-3 join-worker-3.ign
+ NAME=join-worker-3
+ IGN=join-worker-3.ign
+ DOM_VOL=join-worker-3.qcow2
+ IGN_VOL=/var/lib/libvirt/images/join-worker-3.ign
+ sudo qemu-img create -f qcow2 -F qcow2 -b /var/lib/libvirt/images/boot.qcow2-1.30 /var/lib/libvirt/images/join-worker-3.qcow2 30G
Formatting '/var/lib/libvirt/images/join-worker-3.qcow2', fmt=qcow2 cluster_size=65536 extended_l2=off compression_type=zlib size=32212254720 backing_file=/var/lib/libvirt/images/boot.qcow2-1.30 backing_fmt=qcow2 lazy_refcounts=off refcount_bits=16
+ sudo cp join-worker-3.ign /var/lib/libvirt/images/join-worker-3.ign
+ sudo virsh pool-refresh images
Pool images refreshed

+ cat
++ uname -m
+ sudo virsh define join-worker-3.xml
Domain 'join-worker-3' defined from join-worker-3.xml

+ sudo virsh start join-worker-3
Domain 'join-worker-3' started

+ sleep 120
++ /home/opc/go/src/github.com/oracle-cne/tests/scenarios/libvirt/deployments/join-3worker/get-domain-ip.sh join-control-plane-1
+ CP1IP=192.168.122.158
+ export KUBECONFIG=kubeconfig.cp1
+ KUBECONFIG=kubeconfig.cp1
+ ssh -o StrictHostKeyChecking=no sshuser@192.168.122.158 sudo cat /etc/kubernetes/admin.conf
Warning: Permanently added '192.168.122.158' (ED25519) to the list of known hosts.
+ ocne application install --namespace kube-flannel --name flannel --release flannel --catalog embedded
INFO[2025-05-15T14:45:41Z] Application installed successfully           
+ ocne cluster start --provider none --kubeconfig kubeconfig.cp1 --auto-start-ui=false
INFO[2025-05-15T14:45:41Z] Installing core-dns into kube-system: ok 
INFO[2025-05-15T14:45:42Z] Installing kube-proxy into kube-system: ok 
INFO[2025-05-15T14:45:45Z] Installing kubernetes-gateway-api-crds into kube-system: ok 
INFO[2025-05-15T14:45:46Z] Installing ui into ocne-system: ok 
INFO[2025-05-15T14:45:46Z] Installing ocne-catalog into ocne-system: ok 
INFO[2025-05-15T14:45:46Z] Kubernetes cluster was created successfully  
INFO[2025-05-15T14:45:46Z] Post install information:


To access the UI, first do kubectl port-forward to allow the browser to access the UI.
Run the following command, then access the UI from the browser using via https://localhost:8443
    kubectl port-forward -n ocne-system service/ui 8443:443
Run the following command to create an authentication token to access the UI:
    kubectl create token ui -n ocne-system 
+ join_node join-worker-1
+ NAME=join-worker-1
++ /home/opc/go/src/github.com/oracle-cne/tests/scenarios/libvirt/deployments/join-3worker/get-domain-ip.sh join-worker-1
+ IP=192.168.122.116
+ ssh -o StrictHostKeyChecking=no sshuser@192.168.122.116 sudo cat /etc/kubernetes/admin.conf
Warning: Permanently added '192.168.122.116' (ED25519) to the list of known hosts.
+ ocne cluster join -k kubeconfig.node --node join-worker-1 --destination kubeconfig.cp1 --log-level debug
DEBU[2025-05-15T14:45:47Z] Sanitizing kubeconfig.node                   
DEBU[2025-05-15T14:45:47Z] Sanitizing kubeconfig.cp1                    
DEBU[2025-05-15T14:45:47Z] Sanitizing kubeconfig.node                   
INFO[2025-05-15T14:45:47Z] Updating node with join configuration        
INFO[2025-05-15T14:45:53Z] Waiting for pod ocne-system/join-node-join-worker-1-pod to be ready: ok 
INFO[2025-05-15T14:45:54Z] Node join-worker-1 successfully updated      
+ join_node join-worker-2
+ NAME=join-worker-2
++ /home/opc/go/src/github.com/oracle-cne/tests/scenarios/libvirt/deployments/join-3worker/get-domain-ip.sh join-worker-2
+ IP=192.168.122.14
+ ssh -o StrictHostKeyChecking=no sshuser@192.168.122.14 sudo cat /etc/kubernetes/admin.conf
Warning: Permanently added '192.168.122.14' (ED25519) to the list of known hosts.
+ ocne cluster join -k kubeconfig.node --node join-worker-2 --destination kubeconfig.cp1 --log-level debug
DEBU[2025-05-15T14:45:54Z] Sanitizing kubeconfig.node                   
DEBU[2025-05-15T14:45:54Z] Sanitizing kubeconfig.cp1                    
DEBU[2025-05-15T14:45:54Z] Sanitizing kubeconfig.node                   
INFO[2025-05-15T14:45:54Z] Updating node with join configuration        
INFO[2025-05-15T14:46:00Z] Waiting for pod ocne-system/join-node-join-worker-2-pod to be ready: ok 
INFO[2025-05-15T14:46:01Z] Node join-worker-2 successfully updated      
+ join_node join-worker-3
+ NAME=join-worker-3
++ /home/opc/go/src/github.com/oracle-cne/tests/scenarios/libvirt/deployments/join-3worker/get-domain-ip.sh join-worker-3
+ IP=192.168.122.95
+ ssh -o StrictHostKeyChecking=no sshuser@192.168.122.95 sudo cat /etc/kubernetes/admin.conf
Warning: Permanently added '192.168.122.95' (ED25519) to the list of known hosts.
+ ocne cluster join -k kubeconfig.node --node join-worker-3 --destination kubeconfig.cp1 --log-level debug
DEBU[2025-05-15T14:46:01Z] Sanitizing kubeconfig.node                   
DEBU[2025-05-15T14:46:01Z] Sanitizing kubeconfig.cp1                    
DEBU[2025-05-15T14:46:01Z] Sanitizing kubeconfig.node                   
INFO[2025-05-15T14:46:01Z] Updating node with join configuration        
INFO[2025-05-15T14:46:07Z] Waiting for pod ocne-system/join-node-join-worker-3-pod to be ready: ok 
INFO[2025-05-15T14:46:08Z] Node join-worker-3 successfully updated      
+ sleep 30
+ kubectl get node
NAME                   STATUS   ROLES           AGE    VERSION
join-control-plane-1   Ready    control-plane   102s   v1.30.10+1.el8
join-worker-1          Ready    <none>          32s    v1.30.10+1.el8
join-worker-2          Ready    <none>          18s    v1.30.10+1.el8
join-worker-3          Ready    <none>          17s    v1.30.10+1.el8
+ join_node join-control-plane-2
+ NAME=join-control-plane-2
++ /home/opc/go/src/github.com/oracle-cne/tests/scenarios/libvirt/deployments/join-3worker/get-domain-ip.sh join-control-plane-2
+ IP=192.168.122.214
+ ssh -o StrictHostKeyChecking=no sshuser@192.168.122.214 sudo cat /etc/kubernetes/admin.conf
+ ocne cluster join -k kubeconfig.node --node join-control-plane-2 --destination kubeconfig.cp1 --log-level debug
DEBU[2025-05-15T14:46:39Z] Sanitizing kubeconfig.node                   
DEBU[2025-05-15T14:46:39Z] Sanitizing kubeconfig.cp1                    
DEBU[2025-05-15T14:46:39Z] Sanitizing kubeconfig.node                   
INFO[2025-05-15T14:46:39Z] Updating node with join configuration        
INFO[2025-05-15T14:46:44Z] Waiting for pod ocne-system/join-node-join-control-plane-2-pod to be ready: ok 
INFO[2025-05-15T14:46:45Z] Node join-control-plane-2 successfully updated 
+ sleep 10
+ join_node join-control-plane-3
+ NAME=join-control-plane-3
++ /home/opc/go/src/github.com/oracle-cne/tests/scenarios/libvirt/deployments/join-3worker/get-domain-ip.sh join-control-plane-3
+ IP=192.168.122.164
+ ssh -o StrictHostKeyChecking=no sshuser@192.168.122.164 sudo cat /etc/kubernetes/admin.conf
Warning: Permanently added '192.168.122.164' (ED25519) to the list of known hosts.
+ ocne cluster join -k kubeconfig.node --node join-control-plane-3 --destination kubeconfig.cp1 --log-level debug
DEBU[2025-05-15T14:46:56Z] Sanitizing kubeconfig.node                   
DEBU[2025-05-15T14:46:56Z] Sanitizing kubeconfig.cp1                    
DEBU[2025-05-15T14:46:56Z] Sanitizing kubeconfig.node                   
INFO[2025-05-15T14:46:56Z] Updating node with join configuration        
INFO[2025-05-15T14:47:01Z] Waiting for pod ocne-system/join-node-join-control-plane-3-pod to be ready: ok 
INFO[2025-05-15T14:47:02Z] Node join-control-plane-3 successfully updated 
+ sleep 30
+ kubectl get node
NAME                   STATUS   ROLES           AGE     VERSION
join-control-plane-1   Ready    control-plane   2m36s   v1.30.10+1.el8
join-control-plane-2   Ready    <none>          27s     v1.30.10+1.el8
join-control-plane-3   Ready    <none>          7s      v1.30.10+1.el8
join-worker-1          Ready    <none>          86s     v1.30.10+1.el8
join-worker-2          Ready    <none>          72s     v1.30.10+1.el8
join-worker-3          Ready    <none>          71s     v1.30.10+1.el8
```

The ignition files used in this demo are simple, used only to do things like set up ssh keys, hostnames,  and password-less sudo.  For example:

```
$ cat join-worker-1.ign 
{
  "ignition": {
    "version": "3.4.0"
  },
  "passwd": {
    "users": [
      {
        "groups": [
          "wheel"
        ],
        "name": "sshuser",
        "passwordHash": "...",
        "sshAuthorizedKeys": [
          "..."
        ]
      }
    ]
  },
  "storage": {
    "files": [
      {
        "path": "/etc/hostname",
        "contents": {
          "compression": "",
          "source": "data:,join-worker-1"
        }
      },
      {
        "path": "/etc/sudoers",
        "append": [
          {
            "compression": "",
            "source": "data:,%25wheel%09ALL%3D(ALL)%09NOPASSWD%3A%20ALL"
          }
        ]
      }
    ]
  },
  "systemd": {
    "units": [
      {
        "dropins": [
          {
            "contents": "[Service]\nEnvironment=ACTION=\nNET_INTERFACE=enp1s0",
            "name": "bootstrap.conf"
          }
        ],
        "enabled": true,
        "name": "ocne.service"
      }
    ]
  }
}
```