### PR TITLE
Added missing repos when building cli for Oracle Linux 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ Building the CLI requires a variety of libraries and utilities.
 - pkg-config
 - gpgme
 
+On Oracle Linux 8, please enable below dnf repos:
+```
+sudo dnf install -y oracle-ocne-release-el8
+sudo dnf config-manager --enable ol8_codeready_builder ol8_ocne
+```
+
 These dependencies can be installed on Oracle Linux 8 and Oracle Linux 9
 by leveraging `yum-buildep`.
 


### PR DESCRIPTION
Fixes below errors
```
sudo yum-builddep buildrpm/ocne.spec
....
....
No matching package to install: 'device-mapper-devel'
No matching package to install: 'gpgme-devel'
No matching package to install: 'helm >= 3.13.0'
No matching package to install: 'libassuan-devel'
No matching package to install: 'yq'
```

Note:  `ol9_ocne` does not have the necessary dependencies like yq, helm etc for Oracle Linux 9 at the moment. So I am not including it in the PR.