### PR TITLE
Disable ignition after first boot

### DIFF
--- a/pkg/cluster/template/olvm/ignition.go
+++ b/pkg/cluster/template/olvm/ignition.go
@@ -39,6 +39,7 @@ systemctl enable --now crio.service
 systemctl enable kubelet.service
 systemctl enable --now kubeadm.service
 `
+
 	// Used to start services needed for kubeadm service
 	copyKubeconfigDropinFile = "keepalived-copy-kubeconfig.conf"
 	copyKubeconfigDropin     = `[Service]


### PR DESCRIPTION
Use an existing drop-in to disable ignition after first boot.  This is needed until the disable-ignition service is fixed, currently it is not enabled.  See https://github.com/oracle-cne/ock/issues/41

I tested by provisioning a 2 node cluster then rebooting the control plane node, then the worker node.  Both reboots hang without this fix.

Before the reboot you can see that the ignition.firstboot param is gone
```
 rpm-ostree kargs
rw ip=dhcp rd.neednet=1 ignition.platform.id=openstack systemd.firstboot=off crashkernel=auto console=tty0 root=UUID=8b5a,,,d1 rd.timeout=120 ostree=/ostree/boot.1/ock/22687...f935/0
```

Before this, the kargs looked like this ( notice ignition.firstboot=1 )
```
rpm-ostree kargs
rw ip=dhcp rd.neednet=1 ignition.platform.id=openstack ignition.firstboot=1 systemd.firstboot=off crashkernel=auto console=tty0 root=UUID=8b5a8...75d1 rd.timeout=120 ostree=/ostree/boot.1/ock/226878bcd...ee4f935/0
```

See that the service ran
```
systemctl status ocne-disable-ignition.service
  ocne-disable-ignition.service - Disable Ignition
   Loaded: loaded (/usr/lib/systemd/system/ocne-disable-ignition.service; enabled; vendor preset: enabled)
   Active: inactive (dead) since Thu 2025-05-22 18:35:27 UTC; 5min ago
 Main PID: 2215 (code=exited, status=0/SUCCESS)

May 22 18:35:16 paul-gz-control-plane-4hc2g systemd[1]: Starting Disable Ignition...
May 22 18:35:26 paul-gz-control-plane-4hc2g rpm-ostree[1618]: Staging deployment...done
May 22 18:35:26 paul-gz-control-plane-4hc2g rpm-ostree[1618]: Changes queued for next boot. Run "systemctl reboot" to start a reboot
May 22 18:35:26 paul-gz-control-plane-4hc2g sh[2248]: grep: /boot/grub2/grubenv: No such file or directory
May 22 18:35:27 paul-gz-control-plane-4hc2g systemd[1]: ocne-disable-ignition.service: Succeeded.
May 22 18:35:27 paul-gz-control-plane-4hc2g systemd[1]: Started Disable Ignition.
```