### PR TITLE
Identify deprecated charts in the ocne catalog search output

### DIFF
--- a/cmd/catalog/search/search.go
+++ b/cmd/catalog/search/search.go
@@ -96,7 +96,7 @@ func RunCmd(cmd *cobra.Command) error {
 	table.AddRow("APPLICATION", "VERSION")
 	for _, chart := range charts {
 		version := chart.Version
-		if len(chart.Deprecated) > 0 {
+		if chart.Deprecated {
 			version = fmt.Sprintf("%s (deprecated)", version)
 		}
 		table.AddRow(chart.Name, version)

--- a/cmd/catalog/search/search.go
+++ b/cmd/catalog/search/search.go
@@ -95,7 +95,11 @@ func RunCmd(cmd *cobra.Command) error {
 	table := uitable.New()
 	table.AddRow("APPLICATION", "VERSION")
 	for _, chart := range charts {
-		table.AddRow(chart.Name, chart.Version)
+		version := chart.Version
+		if len(chart.Deprecated) > 0 {
+			version = fmt.Sprintf("%s (deprecated)", version)
+		}
+		table.AddRow(chart.Name, version)
 	}
 	fmt.Println(table)
 

--- a/pkg/catalog/types.go
+++ b/pkg/catalog/types.go
@@ -4,10 +4,11 @@
 package catalog
 
 import (
-	"k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/types"
-	"github.com/oracle-cne/ocne/pkg/helm"
 	"time"
+
+	"github.com/oracle-cne/ocne/pkg/helm"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 // CatalogConnection represents a connection to a catalog
@@ -25,17 +26,18 @@ type CatalogConnection interface {
 // ChartMeta represents a single helm chart
 // NOTE: This structure is derived from the JSON return from the catalog service /charts/ endpoint
 type ChartMeta struct {
-	Name        string             `yaml:"name"`
-	Version     string             `yaml:"version"`
-	Description string             `yaml:"description"`
-	ApiVersion  string             `yaml:"apiVersion"`
-	AppVersion  string             `yaml:"appVersion"`
-	KubeVersion string             `yaml:"kubeVersion"`
-	Type        string             `yaml:"type"`
-	Urls        []string           `yaml:"urls"`
-	Created     time.Time          `yaml:"created"`
-	Digest      string             `yaml:"digest"`
-	Annotations map[string]string  `yaml:"annotations"`
+	Name        string            `yaml:"name"`
+	Version     string            `yaml:"version"`
+	Description string            `yaml:"description"`
+	ApiVersion  string            `yaml:"apiVersion"`
+	AppVersion  string            `yaml:"appVersion"`
+	KubeVersion string            `yaml:"kubeVersion"`
+	Type        string            `yaml:"type"`
+	Urls        []string          `yaml:"urls"`
+	Created     time.Time         `yaml:"created"`
+	Digest      string            `yaml:"digest"`
+	Annotations map[string]string `yaml:"annotations"`
+	Deprecated  string            `yaml:"deprecated"`
 }
 
 // Catalog contains the helm chart index of all the charts in the catalog
@@ -59,7 +61,7 @@ type CatalogInfo struct {
 	// Protocol is the catalog protocol for the catalog
 	Protocol string
 
-	// Uri is the URI of the of the catalog
+	// Uri is the URI of the catalog
 	Uri string
 
 	// Port is the port for the service, if one is defined

--- a/pkg/catalog/types.go
+++ b/pkg/catalog/types.go
@@ -37,7 +37,7 @@ type ChartMeta struct {
 	Created     time.Time         `yaml:"created"`
 	Digest      string            `yaml:"digest"`
 	Annotations map[string]string `yaml:"annotations"`
-	Deprecated  string            `yaml:"deprecated"`
+	Deprecated  bool              `yaml:"deprecated"`
 }
 
 // Catalog contains the helm chart index of all the charts in the catalog


### PR DESCRIPTION
Sample output
```
> ocne cat search --name embedded
APPLICATION                	VERSION            
bootstrap-capi             	1.9.4              
bootstrap-capi             	1.7.1              
cert-manager               	1.16.3             
cert-manager               	1.14.5             
cert-manager               	1.9.1              
cert-manager-webhook-oci   	1.1.0              
control-plane-capi         	1.9.4              
control-plane-capi         	1.7.1              
core-capi                  	1.9.4              
core-capi                  	1.7.1              
coredns                    	2.0.0              
csi-driver-nfs             	4.11.0             
dex                        	2.39.1             
externalip-webhook         	1.0.0              
flannel                    	2.0.0              
flannel                    	0.22.3             
fluent-operator            	3.2.0              
fluentd                    	1.14.5 (deprecated)
grafana                    	7.5.17             
ingress-nginx              	1.12.1             
ingress-nginx              	1.9.6              
istio-base                 	1.24.1             
istio-base                 	1.22.6             
istio-base                 	1.20.5             
istio-base                 	1.19.9             
istio-cni                  	1.24.1             
istio-egress               	1.24.1             
istio-egress               	1.22.6             
istio-egress               	1.20.5             
istio-egress               	1.19.9             
istio-gateway              	1.24.1             
istio-gateway              	1.22.6             
istio-ingress              	1.24.1             
istio-ingress              	1.22.6             
istio-ingress              	1.20.5             
istio-ingress              	1.19.9             
istio-ztunnel              	1.24.1             
istiod                     	1.24.1             
istiod                     	1.22.6             
istiod                     	1.20.5             
istiod                     	1.19.9             
keycloak                   	21.1.2 (deprecated)
kube-prometheus-stack      	0.63.0             
kube-proxy                 	2.0.0              
kube-state-metrics         	2.8.2              
kubernetes-gateway-api-crds	1.2.1              
kubevirt                   	1.1.1              
kubevirt                   	1.0.1              
kubevirt                   	0.59.0             
kubevirt                   	0.58.0             
metallb                    	0.13.10            
metallb                    	0.12.1             
multus                     	4.0.2              
oauth2-proxy               	7.8.0              
oci-capi                   	0.16.0             
oci-capi                   	0.15.0             
oci-ccm                    	1.30.0             
oci-ccm                    	1.28.0             
oci-ccm                    	1.27.2             
ocne-catalog               	2.0.0              
olvm-capi                  	1.0.0              
opensearch                 	2.15.0             
opensearch-dashboards      	2.15.0             
ovirt-csi-driver           	4.20.0             
prometheus                 	2.31.1             
prometheus-adapter         	0.10.0             
prometheus-node-exporter   	1.6.1              
rook                       	1.12.3             
rook                       	1.11.6             
rook                       	1.10.9             
tigera-operator            	1.32.4             
tigera-operator            	1.29.3             
ui                         	2.0.0              
```