### PR TITLE
Add default network interface for olvm

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -71,13 +71,13 @@ func GetDefaultConfig() (*types.Config, error) {
 				Profile:     constants.OciDefaultProfile,
 				ImageBucket: constants.OciBucket,
 				ControlPlaneShape: types.OciInstanceShape{
-					Shape: constants.OciVmStandardA1Flex,
-					Ocpus: constants.OciControlPlaneOcpus,
+					Shape:          constants.OciVmStandardA1Flex,
+					Ocpus:          constants.OciControlPlaneOcpus,
 					BootVolumeSize: constants.OciBootVolumeSize,
 				},
 				WorkerShape: types.OciInstanceShape{
-					Shape: constants.OciVmStandardE4Flex,
-					Ocpus: constants.OciWorkerOcpus,
+					Shape:          constants.OciVmStandardE4Flex,
+					Ocpus:          constants.OciWorkerOcpus,
 					BootVolumeSize: constants.OciBootVolumeSize,
 				},
 			},
@@ -86,11 +86,17 @@ func GetDefaultConfig() (*types.Config, error) {
 				ControlPlaneMachine: types.OlvmMachine{
 					VirtualMachine: types.OlvmVirtualMachine{
 						Memory: constants.OLVMCAPIControlPlaneMemory,
+						Network: types.OlvmVirtualMachineNetwork{
+							Interface: constants.OLVMNetworkInterface,
+						},
 					},
 				},
 				WorkerMachine: types.OlvmMachine{
 					VirtualMachine: types.OlvmVirtualMachine{
 						Memory: constants.OLVMCAPIWorkerMemory,
+						Network: types.OlvmVirtualMachineNetwork{
+							Interface: constants.OLVMNetworkInterface,
+						},
 					},
 				},
 				LocalAPIEndpoint: types.OlvmLocalAPIEndpoint{

--- a/pkg/constants/k8s_constants.go
+++ b/pkg/constants/k8s_constants.go
@@ -138,6 +138,7 @@ const (
 	OLVMCAPIResourcesNamespace = "ocne"
 	OLVMCAPIControlPlaneMemory = "7GB"
 	OLVMCAPIWorkerMemory       = "16GB"
+	OLVMNetworkInterface       = "enp1s0"
 
 	// oVirt CSI Driver constants
 	OvirtCsiSecretName    = "ovirt-csi-creds"


### PR DESCRIPTION
Add default network interface for olvm.

**Tested config with missing interface field for both CP and Worker**

```
      virtualMachine:
        memory: "16GB"
        network:
          interfaceType: virtio
...
```
**Created OLVM cluster**
```
 ocne cluster start  --provider olvm -c ~/.ocne/olvm-paul.yaml
INFO[2025-05-29T13:40:49-04:00] Installing cert-manager into cert-manager: ok 
INFO[2025-05-29T13:40:50-04:00] Installing core-capi into capi-system: ok 
INFO[2025-05-29T13:40:50-04:00] Installing olvm-capi into cluster-api-provider-olvm: ok 
INFO[2025-05-29T13:40:51-04:00] Installing bootstrap-capi into capi-kubeadm-bootstrap-system: ok 
INFO[2025-05-29T13:40:51-04:00] Installing control-plane-capi into capi-kubeadm-control-plane-system: ok 
INFO[2025-05-29T13:40:52-04:00] Waiting for Core Cluster API Controllers: ok 
INFO[2025-05-29T13:40:52-04:00] Waiting for Kubadm Boostrap Cluster API Controllers: ok 
INFO[2025-05-29T13:40:52-04:00] Waiting for Kubadm Control Plane Cluster API Controllers: ok 
INFO[2025-05-29T13:40:52-04:00] Waiting for Olvm Cluster API Controllers: ok 
INFO[2025-05-29T13:40:52-04:00] Applying Cluster API resources               
INFO[2025-05-29T13:40:54-04:00] Waiting for kubeconfig: ok       
INFO[2025-05-29T13:43:34-04:00] Waiting for the Kubernetes cluster to be ready: ok 
INFO[2025-05-29T13:43:34-04:00] Installing applications into workload cluster 
INFO[2025-05-29T13:43:40-04:00] Installing ovirt-csi-driver into ovirt-csi: ok 
INFO[2025-05-29T13:43:44-04:00] Installing core-dns into kube-system: ok 
INFO[2025-05-29T13:43:47-04:00] Installing kube-proxy into kube-system: ok 
INFO[2025-05-29T13:43:50-04:00] Installing kubernetes-gateway-api-crds into kube-system: ok 
INFO[2025-05-29T13:43:53-04:00] Installing flannel into kube-flannel: ok 
INFO[2025-05-29T13:43:56-04:00] Installing ui into ocne-system: ok 
INFO[2025-05-29T13:43:59-04:00] Installing ocne-catalog into ocne-system: ok 
INFO[2025-05-29T13:43:59-04:00] Kubernetes cluster was created successfully  
INFO[2025-05-29T13:47:01-04:00] Waiting for the UI to be ready: ok 
```
