### PR TITLE
Resolve issue of OLVM CAPI cluster node remaining in SchedulingDisabled state

### DIFF
--- a/pkg/cluster/ignition/ignition.go
+++ b/pkg/cluster/ignition/ignition.go
@@ -15,6 +15,8 @@ import (
 	ign34 "github.com/coreos/ignition/v2/config/v3_4"
 	igntypes "github.com/coreos/ignition/v2/config/v3_4/types"
 	"github.com/oracle-cne/ocne/pkg/util"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 const (
@@ -59,7 +61,10 @@ type Group struct {
 func AddUser(ign *igntypes.Config, u *User) error {
 	for _, pu := range ign.Passwd.Users {
 		if pu.Name == u.Name {
-			return fmt.Errorf("A user with name %s is already defined", u.Name)
+			return errors.NewAlreadyExists(schema.GroupResource{
+				Group:    "user",
+				Resource: "user",
+			}, fmt.Sprintf("A user with name %s is already defined", u.Name))
 		}
 	}
 
@@ -97,7 +102,10 @@ func AddUser(ign *igntypes.Config, u *User) error {
 func AddGroup(ign *igntypes.Config, g *Group) error {
 	for _, pg := range ign.Passwd.Groups {
 		if pg.Name == g.Name {
-			return fmt.Errorf("A group with name %s is already defined", g.Name)
+			return errors.NewAlreadyExists(schema.GroupResource{
+				Group:    "group",
+				Resource: "user",
+			}, fmt.Sprintf("A group with name %s is already defined", g.Name))
 		}
 	}
 

--- a/pkg/cluster/ignition/ignition.go
+++ b/pkg/cluster/ignition/ignition.go
@@ -15,8 +15,6 @@ import (
 	ign34 "github.com/coreos/ignition/v2/config/v3_4"
 	igntypes "github.com/coreos/ignition/v2/config/v3_4/types"
 	"github.com/oracle-cne/ocne/pkg/util"
-	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 const (
@@ -61,10 +59,7 @@ type Group struct {
 func AddUser(ign *igntypes.Config, u *User) error {
 	for _, pu := range ign.Passwd.Users {
 		if pu.Name == u.Name {
-			return errors.NewAlreadyExists(schema.GroupResource{
-				Group:    "user",
-				Resource: "user",
-			}, fmt.Sprintf("A user with name %s is already defined", u.Name))
+			return fmt.Errorf("A user with name %s is already defined", u.Name)
 		}
 	}
 
@@ -102,10 +97,7 @@ func AddUser(ign *igntypes.Config, u *User) error {
 func AddGroup(ign *igntypes.Config, g *Group) error {
 	for _, pg := range ign.Passwd.Groups {
 		if pg.Name == g.Name {
-			return errors.NewAlreadyExists(schema.GroupResource{
-				Group:    "group",
-				Resource: "user",
-			}, fmt.Sprintf("A group with name %s is already defined", g.Name))
+			return fmt.Errorf("A group with name %s is already defined", g.Name)
 		}
 	}
 

--- a/pkg/cluster/ignition/library.go
+++ b/pkg/cluster/ignition/library.go
@@ -121,13 +121,6 @@ if [ -f "/etc/kubernetes/admin.conf" ]; then
 	chown keepalived_script:keepalived_script /etc/keepalived/kubeconfig
 	chmod 400 /etc/keepalived/kubeconfig
 fi
-
-# nginx track script user nginx_script needs to read this file
-if [ -f "/etc/kubernetes/kubelet.conf" ]; then
-	cp /etc/kubernetes/kubelet.conf /etc/ocne/nginx/kubeconfig
-	chown nginx_script:nginx_script /etc/ocne/nginx/kubeconfig
-	chmod 400 /etc/ocne/nginx/kubeconfig
-fi
 `
 
 	ContainerRegistryPath    = "/etc/containers/registries.conf"

--- a/pkg/cluster/ignition/library.go
+++ b/pkg/cluster/ignition/library.go
@@ -386,19 +386,6 @@ func InitializeCluster(ci *ClusterInit) (*igntypes.Config, error) {
 		},
 	}
 
-	// Temporary setup of nginx_script user
-	err = AddGroup(ret, &Group{
-		Name:   "nginx_script",
-		System: true,
-	})
-	err = AddUser(ret, &User{
-		Name:         "nginx_script",
-		PrimaryGroup: "nginx_script",
-		Shell:        "/sbin/nologin",
-		System:       true,
-		NoCreateHome: true,
-	})
-
 	// Take all of the resources that were made and stick them into the
 	// ignition structure.  Errors can be ignored because this is a fresh
 	// struct and it is guaranteed that no errors will happen so long as

--- a/pkg/cluster/ignition/library.go
+++ b/pkg/cluster/ignition/library.go
@@ -36,11 +36,12 @@ const (
 	ActionInit    = "init"
 	ActionJoin    = "join"
 
-	KubeletServiceName    = "kubelet.service"
-	CrioServiceName       = "crio.service"
-	IscsidServiceName     = "iscsid.service"
-	KeepalivedServiceName = "keepalived.service"
-	NginxServiceName      = "ocne-nginx.service"
+	KubeletServiceName      = "kubelet.service"
+	CrioServiceName         = "crio.service"
+	IscsidServiceName       = "iscsid.service"
+	KeepalivedServiceName   = "keepalived.service"
+	NginxServiceName        = "ocne-nginx.service"
+	NginxRefreshServiceName = "ocne-nginx-refresh.service"
 
 	// Note that OcneServiceCommonBootstrapPatthen has and seemingly
 	// pointless endline.  That endline is actually very important.

--- a/pkg/cluster/ignition/library.go
+++ b/pkg/cluster/ignition/library.go
@@ -125,7 +125,7 @@ fi
 # nginx track script user nginx_script needs to read this file
 if [ -f "/etc/kubernetes/kubelet.conf" ]; then
 	cp /etc/kubernetes/kubelet.conf /etc/ocne/nginx/kubeconfig
-	chown nginx_script:nginx_script /etc/ocne/nging/kubeconfig
+	chown nginx_script:nginx_script /etc/ocne/nginx/kubeconfig
 	chmod 400 /etc/ocne/nginx/kubeconfig
 fi
 `

--- a/pkg/cluster/ignition/library.go
+++ b/pkg/cluster/ignition/library.go
@@ -386,6 +386,19 @@ func InitializeCluster(ci *ClusterInit) (*igntypes.Config, error) {
 		},
 	}
 
+	// Temporary setup of nginx_script user
+	err = AddGroup(ret, &Group{
+		Name:   "nginx_script",
+		System: true,
+	})
+	err = AddUser(ret, &User{
+		Name:         "nginx_script",
+		PrimaryGroup: "nginx_script",
+		Shell:        "/sbin/nologin",
+		System:       true,
+		NoCreateHome: true,
+	})
+
 	// Take all of the resources that were made and stick them into the
 	// ignition structure.  Errors can be ignored because this is a fresh
 	// struct and it is guaranteed that no errors will happen so long as

--- a/pkg/cluster/ignition/virtual_ip.go
+++ b/pkg/cluster/ignition/virtual_ip.go
@@ -525,7 +525,8 @@ func GenerateAssetsForVirtualIp(bindPort uint16, altPort uint16, virtualIP strin
 
 // IgnitionForVirtualIp add keepalived and nginx services and its files to ignition
 func IgnitionForVirtualIp(ign *igntypes.Config, bindPort uint16, altPort uint16, virtualIP string, proxy *types.Proxy, netInterface string) (*igntypes.Config, error) {
-	// Temporary setup of nginx_script user
+	// Setup nginx_script user. This user may eventually be part of the base ock image;
+	// however, it is being created here for compatibility with existing ock images.
 	err := AddGroup(ign, &Group{
 		Name:   "nginx_script",
 		System: true,

--- a/pkg/cluster/ignition/virtual_ip.go
+++ b/pkg/cluster/ignition/virtual_ip.go
@@ -108,8 +108,6 @@ if [ $? -ne 0 ]; then
   echo $(date): keepalived failed to find nginx bound to port >> /etc/keepalived/log
   return 1
 fi
-
-curl --silent --max-time 2 --insecure https://localhost:{{ .BindPort }}/ -o /dev/null || errorExit "Error GET https://localhost:{{ .BindPort }}/"
 `
 
 	keepAlivedStateScript = `#!/bin/bash

--- a/pkg/cluster/ignition/virtual_ip.go
+++ b/pkg/cluster/ignition/virtual_ip.go
@@ -238,7 +238,7 @@ refreshService() {
       if echo "$node" | grep ':'; then
         node="[$node]"
       fi
-      ESCAPED_SERVERS="$ESCAPED_SERVERS\n    server $node:{{ .AltPort }} fail_timeout=500m max_fails=1;"
+      ESCAPED_SERVERS="$ESCAPED_SERVERS\n    server $node:{{ .AltPort }} fail_timeout=10s max_fails=1;"
     done
 
     sed -e 's/SERVERS/'"$ESCAPED_SERVERS"'/g' /etc/ocne/nginx/nginx.conf.tmpl > /etc/ocne/nginx/nginx.conf

--- a/pkg/cluster/ignition/virtual_ip.go
+++ b/pkg/cluster/ignition/virtual_ip.go
@@ -347,15 +347,6 @@ func GenerateAssetsForVirtualIp(bindPort uint16, altPort uint16, virtualIP strin
 			},
 		},
 		&File{
-			Path:  nginxCheckScriptPath,
-			Mode:  0755,
-			User:  nginxUser,
-			Group: nginxGroup,
-			Contents: FileContents{
-				Source: nginxScript,
-			},
-		},
-		&File{
 			Path:  keepAlivedStateScriptPath,
 			Mode:  0755,
 			User:  keepAlivedUser,
@@ -403,6 +394,15 @@ func GenerateAssetsForVirtualIp(bindPort uint16, altPort uint16, virtualIP strin
 	}
 
 	data.Files = append(data.Files,
+		&File{
+			Path:  nginxCheckScriptPath,
+			Mode:  0755,
+			User:  nginxUser,
+			Group: nginxGroup,
+			Contents: FileContents{
+				Source: nginxScript,
+			},
+		},
 		&File{
 			Path:  nginxConfigPath,
 			Mode:  0644,

--- a/pkg/cluster/ignition/virtual_ip.go
+++ b/pkg/cluster/ignition/virtual_ip.go
@@ -203,7 +203,7 @@ exec podman run --name ocne-nginx --replace --rm --network=host --volume=/etc/oc
 // Allow keepalived_script user to restart keepalived.service
 polkit.addRule(function(action, subject) {
     if (action.id == "org.freedesktop.systemd1.manage-units" &&
-        (action.lookup("unit") == "keepalived.service" &&
+        action.lookup("unit") == "keepalived.service" &&
         subject.user == "keepalived_script") {
         return polkit.Result.YES;
     }
@@ -213,7 +213,7 @@ polkit.addRule(function(action, subject) {
 // Allow nginx_script user to restart ocne-nginx.service
 polkit.addRule(function(action, subject) {
     if (action.id == "org.freedesktop.systemd1.manage-units" &&
-        (action.lookup("unit") == "ocne-nginx.service" &&
+        action.lookup("unit") == "ocne-nginx.service" &&
         subject.user == "nginx_script") {
         return polkit.Result.YES;
     }

--- a/pkg/cluster/ignition/virtual_ip.go
+++ b/pkg/cluster/ignition/virtual_ip.go
@@ -525,6 +525,19 @@ func GenerateAssetsForVirtualIp(bindPort uint16, altPort uint16, virtualIP strin
 
 // IgnitionForVirtualIp add keepalived and nginx services and its files to ignition
 func IgnitionForVirtualIp(ign *igntypes.Config, bindPort uint16, altPort uint16, virtualIP string, proxy *types.Proxy, netInterface string) (*igntypes.Config, error) {
+	// Temporary setup of nginx_script user
+	err := AddGroup(ign, &Group{
+		Name:   "nginx_script",
+		System: true,
+	})
+	err = AddUser(ign, &User{
+		Name:         "nginx_script",
+		PrimaryGroup: "nginx_script",
+		Shell:        "/sbin/nologin",
+		System:       true,
+		NoCreateHome: true,
+	})
+
 	data, err := GenerateAssetsForVirtualIp(bindPort, altPort, virtualIP, proxy, netInterface)
 	if err != nil {
 		return nil, err

--- a/pkg/cluster/ignition/virtual_ip.go
+++ b/pkg/cluster/ignition/virtual_ip.go
@@ -102,12 +102,12 @@ refreshService() {
 refreshService
 
 PORTS=$(netstat -nltp)
-echo $PORT | grep -q {{ .BindPort }}
+echo $PORTS | grep -q {{ .BindPort }}
 if [ $? -ne 0 ]; then
   echo $(date): keepalived failed to find nginx bound to port >> /etc/keepalived/log
   return 1
 fi
-echo $PORT | grep -q {{ .AltPort }}
+echo $PORTS | grep -q {{ .AltPort }}
 if [ $? -ne 0 ]; then
   echo $(date): keepalived failed to find kube-apiserver bound to port >> /etc/keepalived/log
   return 1

--- a/pkg/cluster/ignition/virtual_ip.go
+++ b/pkg/cluster/ignition/virtual_ip.go
@@ -235,7 +235,11 @@ refreshService() {
   fi
 }
 
-refreshService
+# Loop forever, checking for and  updates as needed
+while true; do
+	refreshService
+	sleep 30s
+done
 `
 )
 

--- a/pkg/cluster/ignition/virtual_ip.go
+++ b/pkg/cluster/ignition/virtual_ip.go
@@ -128,6 +128,7 @@ stream {
     listen {{ .BindPort }};
     listen [::]:{{ .BindPort }};
     proxy_pass backend1;
+    proxy_connect_timeout 500m;
   }
 }
 `

--- a/pkg/cluster/ignition/virtual_ip.go
+++ b/pkg/cluster/ignition/virtual_ip.go
@@ -67,7 +67,7 @@ errorExit() {
 
 # update keepalived.conf/nginx.conf and restart keepalived.service/ocne-nginx.service if necessary
 refreshServices() {
-  NODES=$(KUBECONFIG=/etc/keepalived/kubeconfig kubectl --server=https://localhost:{{ .AltPort }} --tls-server-name=$(hostname) get nodes --request-timeout 1m --no-headers --selector 'node-role.kubernetes.io/control-plane' -o wide | awk -v OFS='\t\t' '{print $6}')
+  NODES=$(KUBECONFIG=/etc/keepalived/kubeconfig kubectl --server=https://localhost:{{ .AltPort }} --tls-server-name=$(hostname) get nodes --request-timeout 1m --no-headers --selector 'node-role.kubernetes.io/control-plane' -o wide | grep -v SchedulingDisabled | awk -v OFS='\t\t' '{print $6}')
   if [ $? -ne 0 ]; then
     return 0
   fi

--- a/pkg/cluster/ignition/virtual_ip.go
+++ b/pkg/cluster/ignition/virtual_ip.go
@@ -9,6 +9,7 @@ import (
 	igntypes "github.com/coreos/ignition/v2/config/v3_4/types"
 	"github.com/oracle-cne/ocne/pkg/config/types"
 	"github.com/oracle-cne/ocne/pkg/util"
+	"k8s.io/apimachinery/pkg/api/errors"
 )
 
 const (
@@ -531,6 +532,9 @@ func IgnitionForVirtualIp(ign *igntypes.Config, bindPort uint16, altPort uint16,
 		Name:   "nginx_script",
 		System: true,
 	})
+	if err != nil && !errors.IsAlreadyExists(err) {
+		return nil, err
+	}
 	err = AddUser(ign, &User{
 		Name:         "nginx_script",
 		PrimaryGroup: "nginx_script",
@@ -538,6 +542,9 @@ func IgnitionForVirtualIp(ign *igntypes.Config, bindPort uint16, altPort uint16,
 		System:       true,
 		NoCreateHome: true,
 	})
+	if err != nil && !errors.IsAlreadyExists(err) {
+		return nil, err
+	}
 
 	data, err := GenerateAssetsForVirtualIp(bindPort, altPort, virtualIP, proxy, netInterface)
 	if err != nil {

--- a/pkg/cluster/ignition/virtual_ip.go
+++ b/pkg/cluster/ignition/virtual_ip.go
@@ -1,21 +1,20 @@
-// Copyright (c) 2024, Oracle and/or its affiliates.
+// Copyright (c) 2024, 2025, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package ignition
 
 import (
 	"fmt"
-	igntypes "github.com/coreos/ignition/v2/config/v3_4/types"
 
+	igntypes "github.com/coreos/ignition/v2/config/v3_4/types"
 	"github.com/oracle-cne/ocne/pkg/config/types"
 	"github.com/oracle-cne/ocne/pkg/util"
 )
 
 const (
 	keepAlivedServiceName = "keepalived.service"
-	keepAlivedUid = 991
-	keepAlivedUser = "keepalived_script"
-	keepAlivedGroup = "keepalived_script"
+	keepAlivedUser        = "keepalived_script"
+	keepAlivedGroup       = "keepalived_script"
 
 	nginxServiceName = "ocne-nginx.service"
 
@@ -133,6 +132,7 @@ events {
 stream {
   upstream backend1 {
 {{ .Peer }}
+    least_conn;
   }
   server {
     listen {{ .BindPort }};
@@ -216,7 +216,7 @@ type nginxConfigArguments struct {
 	Peer     string
 }
 
-// generateNginxConfig generates a configuration file for nginx to load balaance between
+// generateNginxConfig generates a configuration file for nginx to load balance between
 // all the master nodes in a given cluster.
 func generateNginxConfig(bindPort uint16, peer string) (string, error) {
 	return util.TemplateToString(nginxConfig, &nginxConfigArguments{
@@ -275,7 +275,7 @@ func GenerateAssetsForVirtualIp(bindPort uint16, altPort uint16, virtualIP strin
 			Contents: FileContents{
 				Source: keepAlivedConfig,
 			},
-			User: keepAlivedUser,
+			User:  keepAlivedUser,
 			Group: keepAlivedGroup,
 		},
 		&File{
@@ -292,36 +292,36 @@ func GenerateAssetsForVirtualIp(bindPort uint16, altPort uint16, virtualIP strin
 	}
 	data.Files = append(data.Files,
 		&File{
-			Path: keepAlivedCheckScriptPath,
-			Mode: 0755,
-			User: keepAlivedUser,
+			Path:  keepAlivedCheckScriptPath,
+			Mode:  0755,
+			User:  keepAlivedUser,
 			Group: keepAlivedGroup,
 			Contents: FileContents{
 				Source: keepAlivedCheckScript,
 			},
 		},
 		&File{
-			Path: keepAlivedStateScriptPath,
-			Mode: 0755,
-			User: keepAlivedUser,
+			Path:  keepAlivedStateScriptPath,
+			Mode:  0755,
+			User:  keepAlivedUser,
 			Group: keepAlivedGroup,
 			Contents: FileContents{
 				Source: keepAlivedStateScript,
 			},
 		},
 		&File{
-			Path: "/etc/keepalived/peers",
-			Mode: 0644,
-			User: keepAlivedUser,
+			Path:  "/etc/keepalived/peers",
+			Mode:  0644,
+			User:  keepAlivedUser,
 			Group: keepAlivedGroup,
 			Contents: FileContents{
 				Source: "",
 			},
 		},
 		&File{
-			Path: "/etc/keepalived/log",
-			Mode: 0644,
-			User: keepAlivedUser,
+			Path:  "/etc/keepalived/log",
+			Mode:  0644,
+			User:  keepAlivedUser,
 			Group: keepAlivedGroup,
 			Contents: FileContents{
 				Source: "",
@@ -340,9 +340,9 @@ func GenerateAssetsForVirtualIp(bindPort uint16, altPort uint16, virtualIP strin
 
 	data.Files = append(data.Files,
 		&File{
-			Path: nginxConfigPath,
-			Mode: 0644,
-			User: keepAlivedUser,
+			Path:  nginxConfigPath,
+			Mode:  0644,
+			User:  keepAlivedUser,
 			Group: keepAlivedGroup,
 			Contents: FileContents{
 				Source: nginxConfig,
@@ -377,9 +377,9 @@ func GenerateAssetsForVirtualIp(bindPort uint16, altPort uint16, virtualIP strin
 			},
 		},
 		&File{
-			Path: "/etc/ocne/nginx/servers",
-			Mode: 0644,
-			User: keepAlivedUser,
+			Path:  "/etc/ocne/nginx/servers",
+			Mode:  0644,
+			User:  keepAlivedUser,
 			Group: keepAlivedGroup,
 			Contents: FileContents{
 				Source: "",

--- a/pkg/cluster/ignition/virtual_ip.go
+++ b/pkg/cluster/ignition/virtual_ip.go
@@ -108,11 +108,6 @@ if [ $? -ne 0 ]; then
   echo $(date): keepalived failed to find nginx bound to port >> /etc/keepalived/log
   return 1
 fi
-echo $PORTS | grep -q {{ .AltPort }}
-if [ $? -ne 0 ]; then
-  echo $(date): keepalived failed to find kube-apiserver bound to port >> /etc/keepalived/log
-  return 1
-fi
 
 curl --silent --max-time 2 --insecure https://localhost:{{ .BindPort }}/ -o /dev/null || errorExit "Error GET https://localhost:{{ .BindPort }}/"
 `

--- a/pkg/cluster/ignition/virtual_ip.go
+++ b/pkg/cluster/ignition/virtual_ip.go
@@ -5,11 +5,11 @@ package ignition
 
 import (
 	"fmt"
+	"strings"
 
 	igntypes "github.com/coreos/ignition/v2/config/v3_4/types"
 	"github.com/oracle-cne/ocne/pkg/config/types"
 	"github.com/oracle-cne/ocne/pkg/util"
-	"k8s.io/apimachinery/pkg/api/errors"
 )
 
 const (
@@ -532,7 +532,7 @@ func IgnitionForVirtualIp(ign *igntypes.Config, bindPort uint16, altPort uint16,
 		Name:   "nginx_script",
 		System: true,
 	})
-	if err != nil && !errors.IsAlreadyExists(err) {
+	if err != nil && !strings.Contains(err.Error(), "already defined") {
 		return nil, err
 	}
 	err = AddUser(ign, &User{
@@ -542,7 +542,7 @@ func IgnitionForVirtualIp(ign *igntypes.Config, bindPort uint16, altPort uint16,
 		System:       true,
 		NoCreateHome: true,
 	})
-	if err != nil && !errors.IsAlreadyExists(err) {
+	if err != nil && !strings.Contains(err.Error(), "already defined") {
 		return nil, err
 	}
 

--- a/pkg/cluster/ignition/virtual_ip.go
+++ b/pkg/cluster/ignition/virtual_ip.go
@@ -254,7 +254,7 @@ refreshService() {
 # Loop forever, checking for and  updates as needed
 while true; do
 	refreshService
-	sleep 30s
+	sleep 10s
 done
 `
 )

--- a/pkg/cluster/ignition/virtual_ip.go
+++ b/pkg/cluster/ignition/virtual_ip.go
@@ -338,21 +338,21 @@ func GenerateAssetsForVirtualIp(bindPort uint16, altPort uint16, virtualIP strin
 	}
 	data.Files = append(data.Files,
 		&File{
-			Path:  nginxCheckScriptPath,
-			Mode:  0755,
-			User:  nginxUser,
-			Group: nginxGroup,
-			Contents: FileContents{
-				Source: nginxScript,
-			},
-		},
-		&File{
 			Path:  keepAlivedCheckScriptPath,
 			Mode:  0755,
 			User:  keepAlivedUser,
 			Group: keepAlivedGroup,
 			Contents: FileContents{
 				Source: keepAlivedCheckScript,
+			},
+		},
+		&File{
+			Path:  nginxCheckScriptPath,
+			Mode:  0755,
+			User:  nginxUser,
+			Group: nginxGroup,
+			Contents: FileContents{
+				Source: nginxScript,
 			},
 		},
 		&File{

--- a/pkg/cluster/template/olvm/ignition.go
+++ b/pkg/cluster/template/olvm/ignition.go
@@ -56,15 +56,17 @@ while [ ! -f "/etc/kubernetes/kubelet.conf" ]; do
 done
 
 cp /etc/kubernetes/kubelet.conf /etc/keepalived/kubeconfig
+
+grep -q "/var/lib/kubelet/pki/kubelet-client-current.pem" kubeconfig
+if [ $? -eq 0 ]; then
+	cp /var/lib/kubelet/pki/kubelet-client-current.pem /etc/keepalived/kubelet-client-current.pem
+	chown keepalived_script:keepalived_script /etc/keepalived/kubelet-client-current.pem
+	chmod 400 /etc/keepalived/kubelet-client-current.pem
+	sed -i 's|/var/lib/kubelet/pki/kubelet-client-current.pem|/etc/keepalived/kubelet-client-current.pem|g' kubeconfig
+fi
+
 chown keepalived_script:keepalived_script /etc/keepalived/kubeconfig
-sed -i 's|/var/lib/kubelet/pki/kubelet-client-current.pem|/etc/keepalived/kubelet-client-current.pem|g' kubeconfig
 chmod 400 /etc/keepalived/kubeconfig
-
-cp /var/lib/kubelet/pki/kubelet-client-current.pem /etc/keepalived/kubelet-client-current.pem
-chown keepalived_script:keepalived_script /etc/keepalived/kubelet-client-current.pem
-chmod 400 /etc/keepalived/kubelet-client-current.pem
-
-
 `
 	// Disable ocne.server with a preset file
 	// These need to be disabled because the disable presets set by ignition are not

--- a/pkg/cluster/template/olvm/ignition.go
+++ b/pkg/cluster/template/olvm/ignition.go
@@ -57,9 +57,7 @@ done
 
 cp /etc/kubernetes/kubelet.conf /etc/keepalived/kubeconfig
 
-grep -q "/var/lib/kubelet/pki/kubelet-client-current.pem" kubeconfig
-exit_status=$?
-if [ $exit_status -eq 0 ]; then
+if [ grep -q "/var/lib/kubelet/pki/kubelet-client-current.pem" kubeconfig -eq 0 ]; then
 	cp /var/lib/kubelet/pki/kubelet-client-current.pem /etc/keepalived/kubelet-client-current.pem
 	chown keepalived_script:keepalived_script /etc/keepalived/kubelet-client-current.pem
 	chmod 400 /etc/keepalived/kubelet-client-current.pem

--- a/pkg/cluster/template/olvm/ignition.go
+++ b/pkg/cluster/template/olvm/ignition.go
@@ -57,11 +57,11 @@ done
 
 cp /etc/kubernetes/kubelet.conf /etc/keepalived/kubeconfig
 
-if [[ $(grep "/var/lib/kubelet/pki/kubelet-client-current.pem" "kubeconfig") ]]; then
+if [[ $(grep "/var/lib/kubelet/pki/kubelet-client-current.pem" "/etc/keepalived/kubeconfig") ]]; then
 	cp /var/lib/kubelet/pki/kubelet-client-current.pem /etc/keepalived/kubelet-client-current.pem
 	chown keepalived_script:keepalived_script /etc/keepalived/kubelet-client-current.pem
 	chmod 400 /etc/keepalived/kubelet-client-current.pem
-	sed -i 's|/var/lib/kubelet/pki/kubelet-client-current.pem|/etc/keepalived/kubelet-client-current.pem|g' kubeconfig
+	sed -i 's|/var/lib/kubelet/pki/kubelet-client-current.pem|/etc/keepalived/kubelet-client-current.pem|g' /etc/keepalived/kubeconfig
 fi
 
 chown keepalived_script:keepalived_script /etc/keepalived/kubeconfig

--- a/pkg/cluster/template/olvm/ignition.go
+++ b/pkg/cluster/template/olvm/ignition.go
@@ -138,6 +138,19 @@ func getExtraIgnition(config *types.Config, clusterConfig *types.ClusterConfig, 
 		Enabled: util.BoolPtr(false),
 	})
 
+	// Temporary setup of nginx_script user
+	err = ignition.AddGroup(ign, &ignition.Group{
+		Name:   "nginx_script",
+		System: true,
+	})
+	err = ignition.AddUser(ign, &ignition.User{
+		Name:         "nginx_script",
+		PrimaryGroup: "nginx_script",
+		Shell:        "/sbin/nologin",
+		System:       true,
+		NoCreateHome: true,
+	})
+
 	// Disable some services via preset file in /etc/systemd/system-preset/10-ocne.preset
 	// to override 20-ignition.preset
 	presetFileEtc := &ignition.File{

--- a/pkg/cluster/template/olvm/ignition.go
+++ b/pkg/cluster/template/olvm/ignition.go
@@ -50,12 +50,12 @@ ExecStartPre=/bin/bash -c "/etc/ocne/keepalived-copy-kubeconfig.sh"
 	copyKubeconfigScript     = `#! /bin/bash
 set -x
 set -e
-while [ ! -f "/etc/kubernetes/admin.conf" ]; do
-   echo "Waiting for /etc/kubernetes/admin.conf to exist"
+while [ ! -f "/etc/kubernetes/kubelet.conf" ]; do
+   echo "Waiting for /etc/kubernetes/kubelet.conf to exist"
    sleep 2
 done
 
-cp /etc/kubernetes/admin.conf /etc/keepalived/kubeconfig
+cp /etc/kubernetes/kubelet.conf /etc/keepalived/kubeconfig
 chown keepalived_script:keepalived_script /etc/keepalived/kubeconfig
 chmod 400 /etc/keepalived/kubeconfig
 `

--- a/pkg/cluster/template/olvm/ignition.go
+++ b/pkg/cluster/template/olvm/ignition.go
@@ -134,19 +134,6 @@ func getExtraIgnition(config *types.Config, clusterConfig *types.ClusterConfig, 
 		Enabled: util.BoolPtr(false),
 	})
 
-	// Temporary setup of nginx_script user
-	err = ignition.AddGroup(ign, &ignition.Group{
-		Name:   "nginx_script",
-		System: true,
-	})
-	err = ignition.AddUser(ign, &ignition.User{
-		Name:         "nginx_script",
-		PrimaryGroup: "nginx_script",
-		Shell:        "/sbin/nologin",
-		System:       true,
-		NoCreateHome: true,
-	})
-
 	// Disable some services via preset file in /etc/systemd/system-preset/10-ocne.preset
 	// to override 20-ignition.preset
 	presetFileEtc := &ignition.File{

--- a/pkg/cluster/template/olvm/ignition.go
+++ b/pkg/cluster/template/olvm/ignition.go
@@ -43,14 +43,14 @@ systemctl enable --now kubeadm.service
 	// Used to start services needed for kubeadm service
 	copyKubeconfigDropinFile       = "copy-kubeconfig.conf"
 	copyKubeconfigDropinKeepalived = `[Service]
-ExecStartPre=/bin/bash -c "/etc/keepalived/copy-kubeconfig.sh"
+ExecStartPre=/bin/bash -c "/etc/ocne/keepalived-copy-kubeconfig.sh"
 `
 	copyKubeconfigDropinNginx = `[Service]
-ExecStartPre=/bin/bash -c "/etc/ocne/nginx/copy-kubeconfig.sh"
+ExecStartPre=/bin/bash -c "/etc/ocne/nginx-copy-kubeconfig.sh"
 `
 	// Copy kubeconfig and change ownership
-	copyKubeconfigScriptPathKeepalived = "/etc/keepalived/copy-kubeconfig.sh"
-	copyKubeconfigScriptPathNginx      = "/etc/ocne/nginx/copy-kubeconfig.sh"
+	copyKubeconfigScriptPathKeepalived = "/etc/ocne/keepalived-copy-kubeconfig.sh"
+	copyKubeconfigScriptPathNginx      = "/etc/ocne/nginx-copy-kubeconfig.sh"
 	copyKubeconfigScriptTemplate       = `#! /bin/bash
 set -x
 set -e
@@ -67,12 +67,12 @@ if [[ $(grep "/var/lib/kubelet/pki/kubelet-client-current.pem" "{{ .BasePath }}/
 		sleep 2
 	done
 	cp /var/lib/kubelet/pki/kubelet-client-current.pem {{ .BasePath }}/kubelet-client-current.pem
-	chown nginx_script:nginx_script {{ .BasePath }}/kubelet-client-current.pem
+	chown {{ .Owner }} {{ .BasePath }}/kubelet-client-current.pem
 	chmod 400 {{ .BasePath }}/kubelet-client-current.pem
 	sed -i 's|/var/lib/kubelet/pki/kubelet-client-current.pem|{{ .BasePath }}/kubelet-client-current.pem|g' {{ .BasePath }}/kubeconfig
 fi
 
-chown nginx_script:nginx_script {{ .BasePath }}/kubeconfig
+chown {{ .Owner }} {{ .BasePath }}/kubeconfig
 chmod 400 {{ .BasePath }}/kubeconfig
 `
 	// Disable ocne.server with a preset file
@@ -212,7 +212,7 @@ func getExtraIgnition(config *types.Config, clusterConfig *types.ClusterConfig, 
 	ign = ignition.Merge(ign, patches)
 
 	// If an internal LB is needed for the control plane then the kubeconfig file
-	// needs to be copied to /etc/ocne/nginx
+	// needs to be copied to /etc/keepalived and /etc/ocne/nginx
 	if internalLB {
 		// Copy the kubeconfig file needed by keepalived service to get the
 		// list of cluster nodes

--- a/pkg/cluster/template/olvm/ignition.go
+++ b/pkg/cluster/template/olvm/ignition.go
@@ -57,7 +57,7 @@ done
 
 cp /etc/kubernetes/kubelet.conf /etc/keepalived/kubeconfig
 
-if [ grep -q "/var/lib/kubelet/pki/kubelet-client-current.pem" kubeconfig -eq 0 ]; then
+if grep -q "/var/lib/kubelet/pki/kubelet-client-current.pem" "kubeconfig" .eq 0; then
 	cp /var/lib/kubelet/pki/kubelet-client-current.pem /etc/keepalived/kubelet-client-current.pem
 	chown keepalived_script:keepalived_script /etc/keepalived/kubelet-client-current.pem
 	chmod 400 /etc/keepalived/kubelet-client-current.pem

--- a/pkg/cluster/template/olvm/ignition.go
+++ b/pkg/cluster/template/olvm/ignition.go
@@ -231,7 +231,7 @@ func getExtraIgnition(config *types.Config, clusterConfig *types.ClusterConfig, 
 
 		// Copy the kubeconfig file needed by ocne-nginx service to get the
 		// list of cluster nodes
-		copyKubeconfigScriptSource, err = generateCopyKubeconfigScript("/etc/ocne/ngninx", "ngninx_script:ngninx_script")
+		copyKubeconfigScriptSource, err = generateCopyKubeconfigScript("/etc/ocne/nginx", "nginx_script:nginx_script")
 		if err != nil {
 			return "", err
 		}

--- a/pkg/cluster/template/olvm/ignition.go
+++ b/pkg/cluster/template/olvm/ignition.go
@@ -57,7 +57,7 @@ done
 
 cp /etc/kubernetes/kubelet.conf /etc/keepalived/kubeconfig
 
-if grep -q "/var/lib/kubelet/pki/kubelet-client-current.pem" "kubeconfig" .eq 0; then
+if [[ $(grep "/var/lib/kubelet/pki/kubelet-client-current.pem" "kubeconfig") ]]; then
 	cp /var/lib/kubelet/pki/kubelet-client-current.pem /etc/keepalived/kubelet-client-current.pem
 	chown keepalived_script:keepalived_script /etc/keepalived/kubelet-client-current.pem
 	chmod 400 /etc/keepalived/kubelet-client-current.pem

--- a/pkg/cluster/template/olvm/ignition.go
+++ b/pkg/cluster/template/olvm/ignition.go
@@ -21,11 +21,6 @@ const (
 	preKubeadmDropin = `[Unit]
 Before=kubeadm.service
 `
-	// Used whenever a service has to start after the CAPI
-	// service used to start Kubernetes services on a node
-	postKubeadmDropin = `[Unit]
-After=kubeadm.service
-`
 	// Used to start services needed for kubeadm service
 	enableServicesDropinFile = "enable-services.conf"
 	enableServicesDropin     = `[Service]

--- a/pkg/cluster/template/olvm/ignition.go
+++ b/pkg/cluster/template/olvm/ignition.go
@@ -279,10 +279,6 @@ func getExtraIgnition(config *types.Config, clusterConfig *types.ClusterConfig, 
 			Enabled: util.BoolPtr(true),
 			Dropins: []igntypes.Dropin{
 				{
-					Name:     "post-kubeadm.conf",
-					Contents: util.StrPtr(postKubeadmDropin),
-				},
-				{
 					Name:     copyKubeconfigDropinFile,
 					Contents: util.StrPtr(copyKubeconfigDropinKeepalived),
 				},
@@ -294,10 +290,6 @@ func getExtraIgnition(config *types.Config, clusterConfig *types.ClusterConfig, 
 			Name:    ignition.NginxServiceName,
 			Enabled: util.BoolPtr(true),
 			Dropins: []igntypes.Dropin{
-				{
-					Name:     "post-kubeadm.conf",
-					Contents: util.StrPtr(postKubeadmDropin),
-				},
 				{
 					Name:     copyKubeconfigDropinFile,
 					Contents: util.StrPtr(copyKubeconfigDropinNginx),

--- a/pkg/cluster/template/olvm/ignition.go
+++ b/pkg/cluster/template/olvm/ignition.go
@@ -58,7 +58,8 @@ done
 cp /etc/kubernetes/kubelet.conf /etc/keepalived/kubeconfig
 
 grep -q "/var/lib/kubelet/pki/kubelet-client-current.pem" kubeconfig
-if [ $? -eq 0 ]; then
+exit_status=$?
+if [ $exit_status -eq 0 ]; then
 	cp /var/lib/kubelet/pki/kubelet-client-current.pem /etc/keepalived/kubelet-client-current.pem
 	chown keepalived_script:keepalived_script /etc/keepalived/kubelet-client-current.pem
 	chmod 400 /etc/keepalived/kubelet-client-current.pem

--- a/pkg/cluster/template/olvm/ignition.go
+++ b/pkg/cluster/template/olvm/ignition.go
@@ -58,6 +58,10 @@ done
 cp /etc/kubernetes/kubelet.conf /etc/keepalived/kubeconfig
 
 if [[ $(grep "/var/lib/kubelet/pki/kubelet-client-current.pem" "/etc/keepalived/kubeconfig") ]]; then
+	while [ ! -f "/var/lib/kubelet/pki/kubelet-client-current.pem" ]; do
+		echo "Waiting for /var/lib/kubelet/pki/kubelet-client-current.pem to exist"
+		sleep 2
+	done
 	cp /var/lib/kubelet/pki/kubelet-client-current.pem /etc/keepalived/kubelet-client-current.pem
 	chown keepalived_script:keepalived_script /etc/keepalived/kubelet-client-current.pem
 	chmod 400 /etc/keepalived/kubelet-client-current.pem

--- a/pkg/cluster/template/olvm/ignition.go
+++ b/pkg/cluster/template/olvm/ignition.go
@@ -57,7 +57,14 @@ done
 
 cp /etc/kubernetes/kubelet.conf /etc/keepalived/kubeconfig
 chown keepalived_script:keepalived_script /etc/keepalived/kubeconfig
+sed -i 's|/var/lib/kubelet/pki/kubelet-client-current.pem|/etc/keepalived/kubelet-client-current.pem|g' kubeconfig
 chmod 400 /etc/keepalived/kubeconfig
+
+cp /var/lib/kubelet/pki/kubelet-client-current.pem /etc/keepalived/kubelet-client-current.pem
+chown keepalived_script:keepalived_script /etc/keepalived/kubelet-client-current.pem
+chmod 400 /etc/keepalived/kubelet-client-current.pem
+
+
 `
 	// Disable ocne.server with a preset file
 	// These need to be disabled because the disable presets set by ignition are not

--- a/pkg/commands/cluster/dump/scripts.go
+++ b/pkg/commands/cluster/dump/scripts.go
@@ -67,6 +67,7 @@ journalctl -n 2000 > ./journal.tail.out
 journalctl -u kubelet.service -m --no-hostname > ./journal.kubelet.service
 journalctl -u grow-rootfs.service > ./journal.grow-rootfs.service
 journalctl -u crio.service -m --no-hostname > ./journal.crio.service
+journalctl -u keepalived.service -m --no-hostname > ./journal.keepalived.service
 journalctl -u ocne.service -m --no-hostname > ./journal.ocne.service
 journalctl -u ocne-image-cleanup.service -m --no-hostname > ./journal.ocne-image-cleanup.service
 journalctl -u ocne-nginx.service -m --no-hostname > ./journal.ocne-nginx.service

--- a/pkg/commands/cluster/dump/scripts.go
+++ b/pkg/commands/cluster/dump/scripts.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024, Oracle and/or its affiliates.
+// Copyright (c) 2024, 2025, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package dump
@@ -70,6 +70,7 @@ journalctl -u crio.service -m --no-hostname > ./journal.crio.service
 journalctl -u ocne.service -m --no-hostname > ./journal.ocne.service
 journalctl -u ocne-image-cleanup.service -m --no-hostname > ./journal.ocne-image-cleanup.service
 journalctl -u ocne-nginx.service -m --no-hostname > ./journal.ocne-nginx.service
+journalctl -u ocne-nginx-refresh.service -m --no-hostname > ./journal.ocne-nginx-refresh.service
 journalctl -u ocne-update.service -m --no-hostname > ./journal.ocne-update.service
 journalctl -u ostree-remount.service -m --no-hostname > ./journal.ostree-remount.service
 

--- a/pkg/commands/cluster/join/scripts.go
+++ b/pkg/commands/cluster/join/scripts.go
@@ -14,7 +14,7 @@ chroot /hostroot bash -c "echo \"$JOIN_CONFIG\" > /etc/kubernetes/kubeadm.conf"
 chroot /hostroot sed -i '/Environment=ACTION=/c\Environment=ACTION=join' /etc/systemd/system/ocne.service.d/bootstrap.conf
 chroot /hostroot systemctl daemon-reload
 chroot /hostroot chown keepalived_script:keepalived_script /etc/keepalived/peers  /etc/keepalived/keepalived.conf /etc/keepalived/log || true
-chroot /hostroot chown nginx_script:nginx_script /etc/ocne/nginx/log /etc/ocne/nginx/servers /etc/ocne/nginx/nginx.conf || true
+chroot /hostroot chown nginx_script:nginx_script /etc/ocne/nginx-refresh /etc/ocne/nginx-refresh/log /etc/ocne/nginx-refresh/servers /etc/ocne/nginx/nginx.conf || true
 chroot /hostroot bash -c 'for svc in $ENABLE_SERVICES; do systemctl enable $svc --now; done'
 chroot /hostroot touch /etc/ocne/reset-kubeadm
 chroot /hostroot systemctl restart ocne

--- a/pkg/commands/cluster/join/scripts.go
+++ b/pkg/commands/cluster/join/scripts.go
@@ -14,7 +14,8 @@ chroot /hostroot bash -c "echo \"$JOIN_CONFIG\" > /etc/kubernetes/kubeadm.conf"
 chroot /hostroot sed -i '/Environment=ACTION=/c\Environment=ACTION=join' /etc/systemd/system/ocne.service.d/bootstrap.conf
 chroot /hostroot systemctl daemon-reload
 chroot /hostroot chown keepalived_script:keepalived_script /etc/keepalived/peers  /etc/keepalived/keepalived.conf /etc/keepalived/log || true
-chroot /hostroot chown nginx_script:nginx_script /etc/ocne/nginx-refresh /etc/ocne/nginx-refresh/log /etc/ocne/nginx-refresh/servers /etc/ocne/nginx/nginx.conf || true
+chroot /hostroot chown -R nginx_script:nginx_script || true
+chroot /hostroot chown nginx_script:nginx_script /etc/ocne/nginx/nginx.conf || true
 chroot /hostroot bash -c 'for svc in $ENABLE_SERVICES; do systemctl enable $svc --now; done'
 chroot /hostroot touch /etc/ocne/reset-kubeadm
 chroot /hostroot systemctl restart ocne

--- a/pkg/commands/cluster/join/scripts.go
+++ b/pkg/commands/cluster/join/scripts.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024, Oracle and/or its affiliates.
+// Copyright (c) 2024, 2025, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package join
@@ -13,14 +13,10 @@ chroot /hostroot mv /etc/kubernetes/kubeadm.conf /etc/kubernetes/kubeadm.conf.ba
 chroot /hostroot bash -c "echo \"$JOIN_CONFIG\" > /etc/kubernetes/kubeadm.conf"
 chroot /hostroot sed -i '/Environment=ACTION=/c\Environment=ACTION=join' /etc/systemd/system/ocne.service.d/bootstrap.conf
 chroot /hostroot systemctl daemon-reload
-chroot /hostroot chown keepalived_script:keepalived_script /etc/keepalived/peers /etc/keepalived/keepalived.conf /etc/keepalived/log /etc/ocne/nginx/servers /etc/ocne/nginx/servers /etc/ocne/nginx/nginx.conf || true
+chroot /hostroot chown keepalived_script:keepalived_script /etc/keepalived/peers  /etc/keepalived/keepalived.conf /etc/keepalived/log || true
+chroot /hostroot chown nginx_script:nginx_script /etc/ocne/nginx/log /etc/ocne/nginx/servers /etc/ocne/nginx/nginx.conf || true
 chroot /hostroot bash -c 'for svc in $ENABLE_SERVICES; do systemctl enable $svc --now; done'
 chroot /hostroot touch /etc/ocne/reset-kubeadm
 chroot /hostroot systemctl restart ocne
-`
-
-	// Get the network interface that hosts the route for an IP address
-	defaultRouteScript = `#! /bin/bash
-ip -o route get %s | cut -d' ' -f3
 `
 )


### PR DESCRIPTION
Summary of changes:
- Changes to keepalived
  - Changed /etc/ocne/keepalived-copy-kubeconfig.sh to copy the kubelet kubeconfig to /etc/keepalived, as well as the certificate files (if the kubeconfig does not embed the cert data)
  - Changes to /etc/keepalived/check_apiserver.sh
    - Use the kubelet kubeconfig instead of the admin kubeconfig
    - Added checks for API Server and Nginx being up based on their processes being actively bound to ports
    - Removed logic that managed changes to nginx.conf
- Changes to /etc/ocne/nginx.conf
  - Added least_conn to nginx.conf
  - Added fail_timeout=10s max_fails=1 to each server definition
- Added new service named ocne-nginx-refresh
  - The logic that use to reside in the keepalived service for managing nginx.conf changes was moved to this new service
  - The new service checks run under the user nginx_script. The new user will be added to the base ock image.  The new user is added during the ignition setup in the ocne client.  Eventually that user will also be added to the base ock image.
  - Updated the dump scripts to add the new service
- Added more options to the ignition.AddUser and ignition.AddGroup calls, to expose more functionality available through ignition.

Test suites run:
- ./run_tests.sh --dir ./scenarios/sanity
- ./run_tests.sh --dir ./scenarios/olvm/deployments