### PR TITLE
Set IPV6 default route

### DIFF
--- a/pkg/cluster/template/olvm/capi-olvm.go
+++ b/pkg/cluster/template/olvm/capi-olvm.go
@@ -60,11 +60,11 @@ func GetOlvmTemplate(config *types.Config, clusterConfig *types.ClusterConfig) (
 	// Get the CIDR blocks
 
 	// Build up the extra ignition structures.  Internal LB for control plane only
-	cpIgn, err := getExtraIgnition(config, clusterConfig, true)
+	cpIgn, err := getExtraIgnition(config, clusterConfig, true, &clusterConfig.Providers.Olvm.ControlPlaneMachine.VirtualMachine)
 	if err != nil {
 		return "", err
 	}
-	workerIgn, err := getExtraIgnition(config, clusterConfig, false)
+	workerIgn, err := getExtraIgnition(config, clusterConfig, false, &clusterConfig.Providers.Olvm.WorkerMachine.VirtualMachine)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/cluster/template/olvm/ignition.go
+++ b/pkg/cluster/template/olvm/ignition.go
@@ -123,7 +123,7 @@ func getExtraIgnition(config *types.Config, clusterConfig *types.ClusterConfig, 
 		Enabled:  util.BoolPtr(true),
 		Contents: util.StrPtr(ipv6DefaultRouteService),
 	}
-	ignition.AddFile(ign, ipv6DefaultRoute)
+	ign = ignition.AddUnit(ign, ipv6DefaultRoute)
 
 	// Cluster API has its own kubeadm service to start
 	// kubelet.  Use that one instead of ocne.service.
@@ -204,7 +204,6 @@ func getExtraIgnition(config *types.Config, clusterConfig *types.ClusterConfig, 
 	ign = ignition.Merge(ign, proxy)
 	ign = ignition.Merge(ign, usr)
 	ign = ignition.Merge(ign, patches)
-	ign = ignition.Merge(ign, ipv6DefaultRoute)
 
 	// If an internal LB is needed for the control plane then the kubeconfig file
 	// needs to be copied to /etc/keepalived


### PR DESCRIPTION
Set IPV6 default route on each Kubernetes node if IP V6 is being used.  This fixes problem where Flannel would not start because it could not find the IPV6 interface for the default route.

**Tested IPV6 dual stack**
```
ocne cluster start  --provider olvm -c ~/.ocne/olvm-paul-v6.yaml 
INFO[2025-06-16T16:47:14-04:00] Installing cert-manager into cert-manager: ok 
INFO[2025-06-16T16:47:15-04:00] Installing core-capi into capi-system: ok 
INFO[2025-06-16T16:47:15-04:00] Installing olvm-capi into cluster-api-provider-olvm: ok 
INFO[2025-06-16T16:47:16-04:00] Installing bootstrap-capi into capi-kubeadm-bootstrap-system: ok 
INFO[2025-06-16T16:47:16-04:00] Installing control-plane-capi into capi-kubeadm-control-plane-system: ok 
INFO[2025-06-16T16:47:17-04:00] Waiting for Core Cluster API Controllers: ok 
INFO[2025-06-16T16:47:17-04:00] Waiting for Kubadm Boostrap Cluster API Controllers: ok 
INFO[2025-06-16T16:47:17-04:00] Waiting for Kubadm Control Plane Cluster API Controllers: ok 
INFO[2025-06-16T16:47:17-04:00] Waiting for Olvm Cluster API Controllers: ok 
INFO[2025-06-16T16:47:17-04:00] Applying Cluster API resources               
INFO[2025-06-16T16:47:18-04:00] Waiting for kubeconfig: ok       
INFO[2025-06-16T16:49:53-04:00] Waiting for the Kubernetes cluster to be ready: ok 
INFO[2025-06-16T16:49:53-04:00] Installing applications into workload cluster 
INFO[2025-06-16T16:49:56-04:00] Installing ovirt-csi-driver into ovirt-csi: ok 
INFO[2025-06-16T16:49:57-04:00] Installing core-dns into kube-system: ok 
INFO[2025-06-16T16:49:59-04:00] Installing kube-proxy into kube-system: ok 
INFO[2025-06-16T16:50:01-04:00] Installing kubernetes-gateway-api-crds into kube-system: ok 
INFO[2025-06-16T16:50:03-04:00] Installing flannel into kube-flannel: ok 
INFO[2025-06-16T16:50:05-04:00] Installing ui into ocne-system: ok 
INFO[2025-06-16T16:50:07-04:00] Installing ocne-catalog into ocne-system: ok 
INFO[2025-06-16T16:50:07-04:00] Kubernetes cluster was created successfully  
INFO[2025-06-16T16:53:28-04:00] Waiting for the UI to be ready: ok 

Run the following command to create an authentication token to access the UI:
    KUBECONFIG='/Users/pmackin/.kube/kubeconfig.paul' kubectl create token ui -n ocne-system
Browser window opened, enter 'y' when ready to exit: y
```

**IPV6 route set on Kubernetes CP**
```
ip -6 route
...
default dev enp1s0 metric 1024 pref medium
```

**IPV6 route set on Kubernetes Worker**
```
ip -6 route
...
default dev enp1s0 metric 1024 pref medium
```

**Pods Running**
```
 kk get pod -A 
NAMESPACE      NAME                                               READY   STATUS    RESTARTS      AGE
kube-flannel   kube-flannel-ds-cmhbg                              1/1     Running   0             4m3s
kube-flannel   kube-flannel-ds-fwr4k                              1/1     Running   1 (56s ago)   89s
kube-system    coredns-7dcb9db977-88hh4                           1/1     Running   0             4m9s
kube-system    coredns-7dcb9db977-bkxhv                           1/1     Running   0             4m9s
kube-system    etcd-paul-control-plane-s7gd4                      1/1     Running   0             4m22s
kube-system    kube-apiserver-paul-control-plane-s7gd4            1/1     Running   0             4m25s
kube-system    kube-controller-manager-paul-control-plane-s7gd4   1/1     Running   0             4m26s
kube-system    kube-proxy-dbj58                                   1/1     Running   0             89s
kube-system    kube-proxy-h2wc6                                   1/1     Running   0             4m7s
kube-system    kube-scheduler-paul-control-plane-s7gd4            1/1     Running   0             4m22s
ocne-system    ocne-catalog-8c94cc49f-mwzhf                       1/1     Running   0             4m
ocne-system    ui-5f59d8454b-g94wr                                1/1     Running   0             4m1s
ovirt-csi      ovirt-csi-controller-plugin-bffc5966f-ktf28        5/5     Running   1 (23s ago)   4m11s
ovirt-csi      ovirt-csi-node-plugin-clfnh                        3/3     Running   1 (25s ago)   87s
```

**Notes**
I also tested IPV4 and there was no ipv6 default route service created, nor any IPV6 routes created.