### PR TITLE
Recent ock releases fail to boot if upgrading from a previous version

### DIFF
--- a/pkg/commands/node/update/scripts.go
+++ b/pkg/commands/node/update/scripts.go
@@ -34,7 +34,7 @@ chroot /hostroot /bin/bash <<"EOF"
   for commit in $COMMITS; do
     echo "Checking commit $commit"
     COMMIT_HASH=$(echo "$commit" | sed 's/\([a-z0-9]\+\)\.[0-9]\+/\1/')
-    PKG_VER=$(rpm-ostree db list "$COMMIT_HASH" "shim-$PKG_ARCH" | grep "shim-$PKG_ARCH" | sed "s/^ shim-x64-\([0-9.-]*\).el8[_0-9]*.$RPM_ARCH/\1/")
+    PKG_VER=$(rpm-ostree db list "$COMMIT_HASH" "shim-$PKG_ARCH" | grep "shim-$PKG_ARCH" | sed "s/^ shim-${PKG_ARCH}-\([0-9.-]*\).el8[_0-9]*.${RPM_ARCH}/\1/")
     PKGS=$(echo "${PKGS}${PKG_VER} $commit|")
 
     if [ "$commit" = "$CURRENT_COMMIT" ]; then


### PR DESCRIPTION
Adds an EFI media update procedure when updating a node.  During a node update, all commits are checked to find the most recent package that contains EFI media.  If a new version is available, it is copied into the EFI partition.  For safety, a backup is taken every time the media is updated and a copy of the latest working copy is also retained.