### PR TITLE
Allow for uncompressed layers and avoid home mounts when not required

### DIFF
--- a/pkg/image/image.go
+++ b/pkg/image/image.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024, 2025, Oracle and/or its affiliates.
+// Copyright (c) 2024, 2026, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package image


### PR DESCRIPTION
Now images can be created

```
$ grep '^bootVolumeContainerImage' ~/.ocne/defaults.yaml 
bootVolumeContainerImage: 'containers-storage:localhost/ock:test'

$ unset STORAGE_OPTS
$ echo $STORAGE_OPTS

$ ./out/linux_amd64/ocne image create
INFO[2026-01-20T20:24:54Z] Creating Image                               
INFO[2026-01-20T20:24:54Z] Preparing pod used to create image           
INFO[2026-01-20T20:24:59Z] Waiting for pod ocne-system/ocne-image-builder to be ready: ok 
INFO[2026-01-20T20:24:59Z] Getting local boot image for architecture: amd64 
INFO[2026-01-20T20:25:26Z] Uploading boot image to pod ocne-system/ocne-image-builder: ok 
INFO[2026-01-20T20:28:20Z] Downloading boot image from pod ocne-system/ocne-image-builder: ok 
INFO[2026-01-20T20:28:20Z] New boot image was created successfully at /home/opc/.ocne/images/boot.qcow2-1.33-amd64.oci
```