### PR TITLE
Initialize UPDATE_COMMIT_DATE to NOT be empty string

### DIFF
--- a/pkg/cluster/update/constants.go
+++ b/pkg/cluster/update/constants.go
@@ -18,7 +18,7 @@ OCK_REFS=$(chroot /hostroot ostree refs | grep '^ock')
 BOOT_COMMIT_DATE=$(chroot /hostroot ostree log "$BOOT_REF" | grep '^Date:')
 BOOT_COMMIT_DATE="${BOOT_COMMIT_DATE##Date:+( )}"
 
-UPDATE_COMMIT_DATE=""
+UPDATE_COMMIT_DATE="$BOOT_COMMIT_DATE"
 if echo "$OCK_REFS" | grep -q -e 'ock:ock'; then
 	UPDATE_COMMIT_DATE=$(chroot /hostroot ostree log ock:ock | grep '^Date:')
 	UPDATE_COMMIT_DATE="${UPDATE_COMMIT_DATE##Date:+( )}"

--- a/pkg/cluster/update/update.go
+++ b/pkg/cluster/update/update.go
@@ -854,6 +854,9 @@ func IsUpdateAvailable(node *v1.Node, kubeClient kubernetes.Interface, restConfi
 			return false, err
 		}
 		err = k8s.DeletePod(kubeClient, constants.OCNESystemNamespace, fmt.Sprintf("check-update-%s", node.Name))
+		if err != nil {
+			return false, err
+		}
 		ockInfo := kcConfig.Streams.Out.(*bytes.Buffer)
 
 		timestamps := BootUpdateTimestamps{}


### PR DESCRIPTION
Initialize it to be equal to BOOT_COMMIT_DATE, in case that the ostree refs log doesn't return appropriately, it doesn't error out and it also means update is not available yet.