### PR TITLE
Use the same TTY detection as kubectl

### DIFF
--- a/buildrpm/ocne.spec
+++ b/buildrpm/ocne.spec
@@ -6,7 +6,7 @@
 
 Name: ocne
 Version: 2.3.3
-Release: 2%{dist}
+Release: 3%{dist}
 Vendor: Oracle America
 Summary: Oracle Cloud Native Environment command line interface
 License: UPL 1.0
@@ -72,7 +72,9 @@ chmod 755 %{buildroot}%{_sysconfdir}/bash_completion.d/ocne
 %{_sysconfdir}/bash_completion.d/ocne
 
 %changelog
-=======
+* Wed Apr 08 2026 Daniel Krasinski <daniel.krasinski@oracle.com> - 2.3.3-3
+- Repair an issue where `ocne cluster console` was not accurately determining if stdin was a tty
+
 * Fri Mar 13 2026 Thomas Tanaka <thomas.tanaka@oracle.com> - 2.3.3-2
 - Allow only certain linux editors for EDITOR env vars
 

--- a/buildrpm/ocne.spec
+++ b/buildrpm/ocne.spec
@@ -73,7 +73,7 @@ chmod 755 %{buildroot}%{_sysconfdir}/bash_completion.d/ocne
 
 %changelog
 * Wed Apr 08 2026 Daniel Krasinski <daniel.krasinski@oracle.com> - 2.3.3-3
-- Repair an issue where `ocne cluster console` was not accurately determining if stdin was a tty
+- Repair an issue where ocne cluster console was not accurately determining if stdin was a tty
 
 * Fri Mar 13 2026 Thomas Tanaka <thomas.tanaka@oracle.com> - 2.3.3-2
 - Allow only certain linux editors for EDITOR env vars

--- a/go.mod
+++ b/go.mod
@@ -49,6 +49,8 @@ require (
 	sigs.k8s.io/yaml v1.6.0
 )
 
+require github.com/moby/term v0.5.2
+
 require (
 	dario.cat/mergo v1.0.1 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c // indirect
@@ -172,7 +174,6 @@ require (
 	github.com/moby/sys/capability v0.3.0 // indirect
 	github.com/moby/sys/mountinfo v0.7.2 // indirect
 	github.com/moby/sys/user v0.3.0 // indirect
-	github.com/moby/term v0.5.2 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 // indirect

--- a/pkg/util/stdin.go
+++ b/pkg/util/stdin.go
@@ -5,23 +5,14 @@ package util
 
 import (
 	"os"
+
+	"github.com/moby/term"
 )
 
-// FileIsTTY gives a best guess that a given file represents
-// a TTY or PTY.  The current best guess is that the file is
-// a character device.
-//
-// While it is possible for character devices not to be TTYs,
-// it is unlikely to be true in the context of this code.  A
-// common counterexample is something like a disk.  If someone
-// is trying to do something like pipe a disk to stdin, then
-// they are being silly and some odd behavior can be tolerated.
+// FileIsTTY reports whether a given file is attached to a terminal.
+// Use the same check as kubectl so both commands agree when stdin/stdout
+// is a character device that is not actually a TTY.
 func FileIsTTY(f *os.File) (bool, error) {
-	fi, err := f.Stat()
-	if err != nil {
-		return false, err
-	}
-
-	isCharDevice := fi.Mode()&os.ModeCharDevice != 0
-	return isCharDevice, nil
+	_, isTTY := term.GetFdInfo(f)
+	return isTTY, nil
 }


### PR DESCRIPTION
This addresses #521.  As the comment in the original implementation notes, there is a possibility that a character device that is not a TTY is used as stdin.  Turns out there is actually an interesting example: /dev/null.